### PR TITLE
Platform-2057 collection API sort / dir documentation fixes (REVIEW)

### DIFF
--- a/source/includes/_common.md
+++ b/source/includes/_common.md
@@ -9,10 +9,8 @@ Argument | Description
 -------- | -----------
 async | Whether the API call is asynchronous.  For endpoints that offer both synchronous and asynchronous operation, a boolean can be used for this parameter to specify which mode of operation you desire; if the async parameter is omitted, the synchronous mode will be used. For POST requests, the async parameter should be included along with other JSON data being POSTed. When async is true, the API client has the option of including a callback URL so that it can be notified when the asynchronous processing is complete.
 application_data | API client applications may include custom application data in requests to help support scenarios where an application is unable to store the activity id and wishes to include application specific data in their API requests so that the information will be stored on the request's activity and returned to the application in asynchronous callbacks. This can be useful for scenarios where you want to directly associate a PokitDok Platform API request with some identifier(s) in your system so that you can do direct lookups to associate responses with the appropriate information. For example, suppose you wish to fire off a number of eligibility or claims requests and want to include some identifiers specific to your application. By including the identifier(s) you need in the request's application_data section, you can easily do direct lookups using those identifiers when you receive the API response.
-dir | The direction that a list is sorted, ascending or descending (only for collection requests)
 limit | The number of objects to return in a list (only for collection requests)
 offset | The number of objects to skip when paging through a list (only for collection requests)
-sort | The field to sort the list of objects by (only for collection requests)
 
 ## The Meta and Data Sections
 The response payload for all endpoints consists of a meta key and a data key.

--- a/source/includes/_providers.md
+++ b/source/includes/_providers.md
@@ -37,7 +37,7 @@ radius | {string} | Search distance from geographic centerpoint, with unit (e.g.
 specialty | {string} | The provider's specialty name (e.g. "RHEUMATOLOGY")
 state | {string} | Name of U.S. state in which to search for providers (e.g. "CA" or "SC")
 zipcode | {string} | Geographic center point in which to search for providers (e.g. "94401")
-sort | {string} | Accepted values include 'distance' (default) or 'rank'.  'distance' sort requires city & state or zipcode parameters otherwise results will sorted by 'rank'.
+sort | {string} | Accepted values include 'distance' (default) or 'rank'.  'distance' sort requires city & state or zipcode parameters otherwise sort will be 'rank'.
 
 
 The response from the /providers/ endpoints contain the following fields:

--- a/source/includes/_providers.md
+++ b/source/includes/_providers.md
@@ -73,4 +73,4 @@ provider.facebook_url | {string} | Optional: (verified providers only) Provider 
 provider.small_image_url | {string} | Optional: (verified providers only) Provider small image URL
 provider.twitter_url | {string} | Optional: (verified providers only) Provider Twitter URL
 provider.website_url | {string} | Optional: (verified providers only) Provider website URL
-distance | {string} | When location data is provided and sort is 'distance' (the default) this is the distance from the city+state or zipcode centroid
+distance | {string} | When sort is 'distance' (default) this is the distance from the city & state or zipcode centroid

--- a/source/includes/_providers.md
+++ b/source/includes/_providers.md
@@ -37,7 +37,7 @@ radius | {string} | Search distance from geographic centerpoint, with unit (e.g.
 specialty | {string} | The provider's specialty name (e.g. "RHEUMATOLOGY")
 state | {string} | Name of U.S. state in which to search for providers (e.g. "CA" or "SC")
 zipcode | {string} | Geographic center point in which to search for providers (e.g. "94401")
-sort | {string} | Acceptable values include 'distance' (the default) or 'rank' for sorting.  By default results are sorted by increasing distance from city/state or zipcode centroid location.
+sort | {string} | Accepted values include 'distance' (default) or 'rank'.  'distance' sort requires city & state or zipcode parameters otherwise results will sorted by 'rank'.
 
 
 The response from the /providers/ endpoints contain the following fields:

--- a/source/includes/_providers.md
+++ b/source/includes/_providers.md
@@ -37,6 +37,8 @@ radius | {string} | Search distance from geographic centerpoint, with unit (e.g.
 specialty | {string} | The provider's specialty name (e.g. "RHEUMATOLOGY")
 state | {string} | Name of U.S. state in which to search for providers (e.g. "CA" or "SC")
 zipcode | {string} | Geographic center point in which to search for providers (e.g. "94401")
+sort | {string} | Acceptable values include 'distance' (the default) or 'rank' for sorting.  By default results are sorted by increasing distance from city/state or zipcode centroid location.
+
 
 The response from the /providers/ endpoints contain the following fields:
 
@@ -71,3 +73,4 @@ provider.facebook_url | {string} | Optional: (verified providers only) Provider 
 provider.small_image_url | {string} | Optional: (verified providers only) Provider small image URL
 provider.twitter_url | {string} | Optional: (verified providers only) Provider Twitter URL
 provider.website_url | {string} | Optional: (verified providers only) Provider website URL
+distance | {string} | When location data is provided and sort is 'distance' (the default) this is the distance from the city+state or zipcode centroid


### PR DESCRIPTION
update/clarify documentation with respect to collection API sort and dir keyword arguments.  this should be deployed with PLATFORM-1974.