### PR TITLE
PLATFORM-2822: IDM and Scheduling documentation updates. 

### DIFF
--- a/source/includes/_identity.md
+++ b/source/includes/_identity.md
@@ -193,8 +193,8 @@ The location and provider_uuid values correspond to provider resources accessed 
 
 | Endpoint           | HTTP Method | Description                                                    |
 |--------------------|-------------|----------------------------------------------------------------|
-| /identity/<uuid>   | GET         | Returns a single identity resource                             |
-| /identity?<params> | GET         | Returns one or more identity resources meeting search criteria |
+| /identity/{uuid}   | GET         | Returns a single identity resource                             |
+| /identity?{params} | GET         | Returns one or more identity resources meeting search criteria |
 
 Supported query parameters include:
 
@@ -214,4 +214,4 @@ Supported query parameters include:
 
 | Endpoint         | HTTP Method | Description                                                         |
 |------------------|-------------|---------------------------------------------------------------------|
-| /identity/<uuid> | PUT         | Updates an existing identity resource. Returns the updated resource |
+| /identity/{uuid} | PUT         | Updates an existing identity resource. Returns the updated resource |

--- a/source/includes/_identity.md
+++ b/source/includes/_identity.md
@@ -1,0 +1,217 @@
+Identity Management
+-------------------
+
+> Example creating an identity resource
+
+```shell
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json"
+ -XPOST -d '{
+    "prefix": "Mr.",
+       "first_name": "Oscar",
+       "middle_name": "Harold",
+       "last_name": "Whitmire",
+       "suffix": "IV",
+       "birth_date": "2000-05-01",
+       "gender": "male",
+       "email": "oscar@pokitdok.com",
+       "phone": "555-555-5555",
+       "secondary_phone": "333-333-4444",
+       "address": {
+           "address_lines": ["1400 Anyhoo Avenue"],
+           "city": "Springfield",
+           "state": "IL",
+           "zipcode": "90210"
+       },
+       "identifiers": [
+           {
+               "location": [-121.93831, 37.53901],
+               "provider_uuid": "1917f12b-fb6a-4016-93bc-adeb83204c83",
+               "system_uuid": "967d207f-b024-41cc-8cac-89575a1f6fef",
+               "value": "W90100-IG-88"
+
+           }
+       ]    
+    }' https://platform.pokitdok.com/api/v4/identity/
+```
+
+```python
+pd.create_identity({
+    "prefix": "Mr.",
+    "first_name": "Oscar",
+    "middle_name": "Harold",
+    "last_name": "Whitmire",
+    "suffix": "IV",
+    "birth_date": "2000-05-01",
+    "gender": "male",
+    "email": "oscar@pokitdok.com",
+    "phone": "555-555-5555",
+    "secondary_phone": "333-333-4444",
+    "address": {
+        "address_lines": ["1400 Anyhoo Avenue"],
+        "city": "Springfield",
+        "state": "IL",
+        "zipcode": "90210"
+    },
+    "identifiers": [
+        {
+            "location": [-121.93831, 37.53901],
+            "provider_uuid": "1917f12b-fb6a-4016-93bc-adeb83204c83",
+            "system_uuid": "967d207f-b024-41cc-8cac-89575a1f6fef",
+            "value": "W90100-IG-88"
+
+        }
+    ]
+})
+```
+
+> Example updating an identity resource
+
+```shell
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json"
+ -XPUT -d '{
+    "prefix": "Mr.",
+       "first_name": "Oscar",
+       "middle_name": "Harold",
+       "last_name": "Whitmire",
+       "suffix": "IV",
+       "birth_date": "2000-05-01",
+       "gender": "male",
+       "email": "oscar.whitmire@pokitdok.com",
+       "phone": "555-555-5555",
+       "secondary_phone": "333-333-4444",
+       "address": {
+           "address_lines": ["1400 Anyhoo Avenue"],
+           "city": "Springfield",
+           "state": "IL",
+           "zipcode": "90210"
+       },
+       "identifiers": [
+           {
+               "location": [-121.93831, 37.53901],
+               "provider_uuid": "1917f12b-fb6a-4016-93bc-adeb83204c83",
+               "system_uuid": "967d207f-b024-41cc-8cac-89575a1f6fef",
+               "value": "W90100-IG-88"
+
+           }
+       ]    
+    }' "https://platform.pokitdok.com/api/v4/identity/881bc095-2068-43cb-9783-cce630364122"
+```
+
+```python
+pd.update_identity("881bc095-2068-43cb-9783-cce630364122", {
+    "prefix": "Mr.",
+    "first_name": "Oscar",
+    "middle_name": "Harold",
+    "last_name": "Whitmire",
+    "suffix": "IV",
+    "birth_date": "2000-05-01",
+    "gender": "male",
+    "email": "oscar.whitmire@pokitdok.com",
+    "phone": "555-555-5555",
+    "secondary_phone": "333-333-4444",
+    "address": {
+        "address_lines": ["1400 Anyhoo Avenue"],
+        "city": "Springfield",
+        "state": "IL",
+        "zipcode": "90210"
+    },
+    "identifiers": [
+        {
+            "location": [-121.93831, 37.53901],
+            "provider_uuid": "1917f12b-fb6a-4016-93bc-adeb83204c83",
+            "system_uuid": "967d207f-b024-41cc-8cac-89575a1f6fef",
+            "value": "W90100-IG-88"
+
+        }
+    ]
+})
+```
+
+> Query for a single identity resource
+
+```shell
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" "https://platform.pokitdok.com/api/v4/identity/881bc095-2068-43cb-9783-cce630364122"
+```
+
+```python
+pd.identity("881bc095-2068-43cb-9783-cce630364122")
+```
+
+> Query for one or more identity resources using parameters
+
+```shell
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" "https://platform.pokitdok.com/api/v4/identity?first_name=Oscar&last_name=Whitmire&gender=male"
+```
+
+```python
+pd.identity(first_name='Oscar', last_name='Whitmire', gender='male')
+```
+
+**Available modes of operation: real-time**
+
+PokitDok's Identity Management (IdM) API queries an EMPI (Enterprise Master Patient Index) and/or MPI (Master Patient Index), both typically components of an EMR or EHR system, to find a patient identifier and details in the target EMR/EHR system. This helps providers identify the patient through past visits or other records within other EMR/EHR systems.
+
+Available Identity endpoints:
+
+| Endpoint   | HTTP Method | Description                                                            |
+|------------|-------------|------------------------------------------------------------------------|
+| /identity/ | POST        | Creates an identity resource. Returns the created resource with a uuid |
+
+The /identity/ endpoint accepts the following parameters:
+
+| Field                 | Type     | Description                                                                                                        |
+|-----------------------|----------|--------------------------------------------------------------------------------------------------------------------|
+| address.address_lines | {list}   | Address lines                                                                                                      |
+| address.city          | {string} | Address city                                                                                                       |
+| address.state         | {string} | Two character state abbreviation                                                                                   |
+| address.zipcode       | {string} | Address zipcode. Supports standard 5 digit code or "zip+4" with a "-". Ex:29407-3458                               |
+| birth_date            | {string} | Birth date in ISO-8601 format. Ex: 1990-01-01                                                                      |
+| email                 | {string} | Valid email address including "@" separator and appropriate domain prefix                                          |
+| first_name            | {string} | First name                                                                                                         |
+| gender                | {string} | Valid values include: male, female, or unknown                                                                     |
+| identifiers           | {list}   | List of external identifiers. Each identifier entry is qualified using a system_uuid, provider_uuid, and location. |
+| last_name             | {string} | Last name                                                                                                          |
+| member_id             | {string} | The primary insurance membership id associated with the identity resource                                          |
+| middle_name           | {string} | Middle name                                                                                                        |
+| phone                 | {string} | Primary phone number                                                                                               |
+| prefix                | {string} | Prefix/Title                                                                                                       |
+| secondary_phone       | {string} | Secondary phone number                                                                                             |
+| ssn                   | {string} | Social security number                                                                                             |
+| suffix                | {string} | Suffix                                                                                                             |
+| uuid                  | {uuid}   | Identity resource unique identifier                                                                                |
+
+Each identifier, or identifiers list entry, represents an external system utilized by a provider at a specific location. Fields within an identifier entry include:
+
+| Field         | Type           | Description                                    |
+|---------------|----------------|------------------------------------------------|
+| location      | {geo-location} | The location of the installed system *optional |
+| provider_uuid | {uuid}         | The unique identifier for the provider         |
+| system_uuid   | {uuid}         | The unique identifier for the system           |
+| value         | {string}       | The identifier value                           |
+
+The location and provider_uuid values correspond to provider resources accessed through the /providers endpoint. system_uuid values correspond to registered systems under the /schedule/schedulers endpoint.
+
+| Endpoint           | HTTP Method | Description                                                    |
+|--------------------|-------------|----------------------------------------------------------------|
+| /identity/<uuid>   | GET         | Returns a single identity resource                             |
+| /identity?<params> | GET         | Returns one or more identity resources meeting search criteria |
+
+Supported query parameters include:
+
+-	address.city
+-	address.state
+-	address.zipcode
+-	birth_date
+-	email
+-	first_name
+-	gender
+-	last_name
+-	member_id
+-	middle_name
+-	prefix
+-	secondary_phone
+-	uuid
+
+| Endpoint         | HTTP Method | Description                                                         |
+|------------------|-------------|---------------------------------------------------------------------|
+| /identity/<uuid> | PUT         | Updates an existing identity resource. Returns the updated resource |

--- a/source/includes/_scheduling.md
+++ b/source/includes/_scheduling.md
@@ -1,5 +1,7 @@
-## Scheduling
-> example fetching all schedulers
+Scheduling
+----------
+
+> Example scheduling request to fetch all schedulers
 
 ```shell
 curl -s -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/api/v4/schedule/schedulers/     
@@ -20,11 +22,11 @@ Response
 ]
 ```
 
-> example fetching a specific scheduler
+> Example scheduling request to fetch a specific scheduler
 
 ```shell
-curl -s -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/api/v4/schedule/schedulers/d8f38f08-8530-11e4-9a71-0800272e8da1
-        
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" "https://platform.pokitdok.com/api/v4/schedule/schedulers/d8f38f08-8530-11e4-9a71-0800272e8da1"
+
 Response
 
 [
@@ -36,11 +38,11 @@ Response
 ]
 ```
 
-> example fetching appointment types
+> Example scheduling request to fetch all appointment types
 
 ```shell
 curl -s -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/api/v4/schedule/appointmenttypes/
-        
+
 Response
 
 [
@@ -61,11 +63,12 @@ Response
       }
 ]
 ```
-> example fetching a specified appointment type
+
+> Example scheduling request to fetch a specific appointment type
 
 ```shell
-curl -s -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/api/v4/schedule/appointmenttypes/ef987691-0a19-447f-814d-f8f3abbf4860
-        
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" "https://platform.pokitdok.com/api/v4/schedule/appointmenttypes/ef987691-0a19-447f-814d-f8f3abbf4860"
+
 Response
 
 [
@@ -78,46 +81,39 @@ Response
     }
 ]
 ```
-> example registering a patient with a provider's scheduling system
+
+> Example scheduling request which registers an existing patient with a provider's scheduling system
+
 ```shell
-curl -s -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/api/v4/schedule/patient/
-
-Request Body
-
-{
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" -XPOST -d '{
     "pd_patient_uuid": "2773f6ff-00cb-460f-823f-5ff2208511e7",
     "pd_provider_uuid": "b691b7f9-bfa8-486d-a689-214ae47ea6f8",
     "location": [32.788110, -79.932364]
-}
+}' https://platform.pokitdok.com/api/v4/schedule/patient/
 
 Response
 
 {
-    "uuid': "2773f6ff-00cb-460f-823f-5ff2208511e7",
-    "email': "peg@emailprovider.com",
-    "phone': "5553331122",
+    "uuid": "2773f6ff-00cb-460f-823f-5ff2208511e7",
+    "email": "peg@emailprovider.com",
+    "phone": "5553331122",
     "birth_date": "1990-01-13",
     "first_name": "Peg",
-    "last_name": 'Patient",
+    "last_name": "Patient",
     "member_id": "PD20150001"
-
-
 }
 ```
 
-> example creating an open slot
+> Example scheduling request to create an open slot
+
 ```shell
-curl -s -XPOST -H "Authorization: Bearer $ACCESS_TOKEN" "https://platform.pokitdok.com/api/v4/schedule/slots/"
-
-Request Body
-
-{
+curl -s -XPOST -H "Authorization: Bearer $ACCESS_TOKEN" - H "Content-Type: application/json" -XPOST -d '{
     "pd_provider_uuid": "b691b7f9-bfa8-486d-a689-214ae47ea6f8",
     "location": [32.788110, -79.932364],
     "appointment_type": "AT1",
     "start_date": "2014-12-16T15:09:34.197709",
     "end_date": "2014-12-16T16:09:34.197717"
-}
+    }' https://platform.pokitdok.com/api/v4/schedule/slots/
 
 Response Body
 {
@@ -131,16 +127,17 @@ Response Body
 }
 ```
 
-> example deleting an open slot
+> Example scheduling request to delete an open slot
+
 ```shell
 curl -s -XDELETE -H "Authorization: Bearer $ACCESS_TOKEN" "https://platform.pokitdok.com/api/v4/schedule/slots/ab21e95b-8fa6-41d4-98b9-9a1f6fcff0d2"
+```
 
-
-> example querying for open slots and booked appointments
+> Example scheduling request used to query for open slots and booked appointments
 
 ```shell
 curl -s -H "Authorization: Bearer $ACCESS_TOKEN" "https://platform.pokitdok.com/api/v4/schedule/appointments/?appointment_type=SS1&start_date=2015-01-14T08:00:00&end_date=2015-01-16T17:00:00&patient_uuid=8ae236ff-9ccc-44b0-8717-42653cd719d0"
-        
+
 Response
 
 [
@@ -165,11 +162,11 @@ Response
 ]
 ```
 
-> example querying for a specific open slot or booked appointment
+> Example scheduling request to query for a specific open slot or booked appointment
 
 ```shell
-curl -s -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/api/v4/schedule/appointments/ef987691-0a19-447f-814d-f8f3abbf4859
-        
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" "https://platform.pokitdok.com/api/v4/schedule/appointments/ef987691-0a19-447f-814d-f8f3abbf4859"
+
 Response
 
 [
@@ -194,27 +191,21 @@ Response
 ]
 ```
 
-```shell
-Request Body
+> Example scheduling request to book an appointment
 
-{
+```shell
+curl -s -XPUT -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" -d '{
     "patient": {
         "_uuid": "500ef469-2767-4901-b705-425e9b6f7f83",
-        "email": "john@johndoe.com",
+        "email": "john@hondoe.com",
         "phone": "800-555-1212",
         "birth_date": "1970-01-01",
         "first_name": "John",
         "last_name": "Doe",
         "member_id": "M000001"
-    },
-    "description": "Welcome to M0d3rN Healthcare"
-}
-``` 
-> example booking an appointment for an open slot:
+        },
+    "description": "Welcome to M0d3rN Healthcare"}' "https://platform.pokitdok.com/api/v4/schedule/appointments/ef987691-0a19-447f-814d-f8f3abbf4859"
 
-```shell
-curl -s -XPUT -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"patient": {"_uuid": "500ef469-2767-4901-b705-425e9b6f7f83", "email": "john@hondoe.com", "phone": "800-555-1212", "birth_date": "1970-01-01", "first_name": "John", "last_name": "Doe", "member_id": "M000001"}, "description": "Welcome to M0d3rN Healthcare"}' https://platform.pokitdok.com/api/v4/schedule/appointments/ef987691-0a19-447f-814d-f8f3abbf4859
-    
 Response
 
 {
@@ -237,18 +228,10 @@ Response
 }
 ```
 
-```shell
-Request Body
-
-{
-    "description": "Welcome to M0d3rN Healthcare"
-}
-```
-
-> example updating an appointment description
+> Example scheduling request to update an appointment description
 
 ```shell
-curl -s -XPUT -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"description": "Welcome to M0d3rN Healthcare"}' https://platform.pokitdok.com/api/v4/schedule/appointments/ef987691-0a19-447f-814d-f8f3abbf4859
+curl -s -XPUT -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"description": "Welcome to M0d3rN Healthcare"}' "https://platform.pokitdok.com/api/v4/schedule/appointments/ef987691-0a19-447f-814d-f8f3abbf4859"
 
 Response
 
@@ -263,96 +246,85 @@ Response
 }
 ```
 
-> curl example of cancelling an appointment
+> Example scheduling request to cancel an appointment
 
 ```shell
-curl -i -XDELETE -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/api/v4/schedule/appointments/ef987691-0a19-447f-814d-f8f3abbf4859
+curl -i -XDELETE -H "Authorization: Bearer $ACCESS_TOKEN"  "https://platform.pokitdok.com/api/v4/schedule/appointments/ef987691-0a19-447f-814d-f8f3abbf4859"
 ```
 
 *Available modes of operation: real-time*
 
-The PokitDok Scheduling API performs schedule aggregation to multiple third party scheduling applications, typically 
-commercial off-the-shelf Practice Management (PM) software, for private practices, provider networks, hospital systems, 
-etc. The PokitDok Scheduling API also provides a built-in scheduling system for providers without a PM. The API provides 
-consumers a means to schedule appointments in a manner independent of the provider's PM system. OAuth scopes are used to 
-restrict access to provider's PM systems and user's personal information.
+The PokitDok Scheduling API performs schedule aggregation to multiple third party scheduling applications, typically commercial off-the-shelf Practice Management (PM) software, for private practices, provider networks, hospital systems, etc. The PokitDok Scheduling API also provides a built-in scheduling system for providers without a PM. The API provides consumers a means to schedule appointments in a manner independent of the provider's PM system. OAuth scopes are used to restrict access to provider's PM systems and user's personal information.
 
 Available Scheduling Endpoints:
 
-Endpoint | HTTP Method | Description
--------- | ----------- | -----------
-/schedule/schedulers/ | GET | Get a list of supported scheduling systems and their UUIDs and descriptions.
+| Endpoint              | HTTP Method | Description                                                                  |
+|-----------------------|-------------|------------------------------------------------------------------------------|
+| /schedule/schedulers/ | GET         | Get a list of supported scheduling systems and their UUIDs and descriptions. |
 
-        
-Endpoint | HTTP Method | Description
--------- | ----------- | -----------
-/schedule/schedulers/{uuid} | GET | Retrieve the data for a specified scheduling system.
+| Endpoint                    | HTTP Method | Description                                          |
+|-----------------------------|-------------|------------------------------------------------------|
+| /schedule/schedulers/{uuid} | GET         | Retrieve the data for a specified scheduling system. |
 
-        
-Endpoint | HTTP Method | Description
--------- | ----------- | -----------
-/schedule/appointmenttypes/ | GET | Get a list of appointment types, their UUIDs, and descriptions.
+| Endpoint                    | HTTP Method | Description                                                     |
+|-----------------------------|-------------|-----------------------------------------------------------------|
+| /schedule/appointmenttypes/ | GET         | Get a list of appointment types, their UUIDs, and descriptions. |
 
+| Endpoint                          | HTTP Method | Description                                         |
+|-----------------------------------|-------------|-----------------------------------------------------|
+| /schedule/appointmenttypes/{uuid} | GET         | Retrieve the data for a specified appointment type. |
 
-Endpoint | HTTP Method | Description
--------- | ----------- | -----------
-/schedule/appointmenttypes/{uuid} | GET | Retrieve the data for a specified appointment type.
+| Endpoint           | HTTP Method | Description                                                                             | Scope                                                                           |
+|--------------------|-------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
+| /schedule/patient/ | POST        | Registers an existing PokitDok user as a patient within a provider's scheduling system. | user_schedule The /schedule/patient/ endpoint accepts the following parameters: |
 
+| Field            | Type           | Description                                             |
+|------------------|----------------|---------------------------------------------------------|
+| pd_patient_uuid  | {string}       | The PokitDok unique identifier for the user record.     |
+| pd_provider_uuid | {string}       | The PokitDok unique identifier for the provider record. |
+| location         | {geo-location} | The geo-location of the provider's physical address.    |
 
-Endpoint | HTTP Method | Description | Scope
--------- | ----------- | ----------- | -----
-/schedule/patient/ | POST | Registers an existing PokitDok user as a patient within a provider's scheduling system. | user_schedule The /schedule/patient/ endpoint accepts the following parameters:
+| Endpoint         | HTTP Method | Description                      | Scope                                                                             |
+|------------------|-------------|----------------------------------|-----------------------------------------------------------------------------------|
+| /schedule/slots/ | POST        | Creates an open scheduling slot. | business_schedule The /schedule/slots/ endpoint accepts the following parameters: |
 
-Field | Type | Description
------ | ---- | -----------
-pd_patient_uuid | {string} | The PokitDok unique identifier for the user record.
-pd_provider_uuid | {string} | The PokitDok unique identifier for the provider record.
-location | {geo-location} | The geo-location of the provider's physical address.
+| Field            | Type           | Description                                                                        |
+|------------------|----------------|------------------------------------------------------------------------------------|
+| pd_provider_uuid | {string}       | The PokitDok unique identifier for the provider record.                            |
+| location         | {geo-location} | The geo-location of the provider's physical address.                               |
+| appointment_type | {string}       | The "appointment_type" used to identify a specific appointment procedure/category. |
+| start_date       | {datetime}     | The beginning date and UTC time of the appointment query, formatted as ISO8601.    |
+| end_date         | {datetime}     | The ending date and UTC time of the appointment query, formatted as ISO8601.       |
 
-Endpoint | HTTP Method | Description | Scope
--------- | ----------- | ----------- | -----
-/schedule/slots/ | POST | Creates an open scheduling slot. | business_schedule The /schedule/slots/ endpoint accepts the following parameters:
+| Endpoint                              | HTTP Method | Description                      | Scope             |
+|---------------------------------------|-------------|----------------------------------|-------------------|
+| /schedule/slots/{pd_appointment_uuid} | DELETE      | Deletes an open scheduling slot. | business_schedule |
 
-Field | Type | Description
------ | ---- | -----------
-pd_provider_uuid | {string} | The PokitDok unique identifier for the provider record.
-location | {geo-location} | The geo-location of the provider's physical address.
-appointment_type | {string} | The "appointment_type" used to identify a specific appointment procedure/category.
-start_date | {datetime} | The beginning date and UTC time of the appointment query, formatted as ISO8601.
-end_date | {datetime} | The ending date and UTC time of the appointment query, formatted as ISO8601.
+| Endpoint                | HTTP Method | Description                                                                                                                                | Scope                                                                                |
+|-------------------------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| /schedule/appointments/ | GET         | Query for open appointment slots (using pd_provider_uuid and location) or booked appointments (using patient_uuid) given query parameters. | user_schedule The /schedule/appointments/ endpoint accepts the following parameters: |
 
-Endpoint | HTTP Method | Description | Scope
--------- | ----------- | ----------- | -----
-/schedule/slots/{pd_appointment_uuid} | DELETE | Deletes an open scheduling slot. | business_schedule
+| Field            | Type           | Description                                                                                                                     |
+|------------------|----------------|---------------------------------------------------------------------------------------------------------------------------------|
+| appointment_type | {string}       | The "appointment_type" used to identify a specific appointment procedure/category.                                              |
+| start_date       | {datetime}     | The beginning date and UTC time of the appointment query, formatted as ISO8601.                                                 |
+| end_date         | {datetime}     | The ending date and UTC time of the appointment query, formatted as ISO8601.                                                    |
+| patient_uuid     | {uuid}         | The PokitDok unique identifier for the patient that has booked an appointment.                                                  |
+| pd_provider_uuid | {uuid}         | The PokitDok unique identifier for the provider that has an open appointment slot.                                              |
+| location         | {geo-location} | The geo-location of the physical address where the provider that has an open appointment slot, formatted [latitude, longitude]. |
 
+| Endpoint                                     | HTTP Method | Description                                                                                                                                      | Scope         |
+|----------------------------------------------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| /schedule/appointments/{pd_appointment_uuid} | GET         | Query for an open appointment slot or a booked appointment given a specific {pd_appointment_uuid}, the (PokitDok unique appointment identifier). | user_schedule |
 
-Endpoint | HTTP Method | Description | Scope
--------- | ----------- | ----------- | -----
-/schedule/appointments/ | GET | Query for open appointment slots (using pd_provider_uuid and location) or booked appointments (using patient_uuid) given query parameters. | user_schedule The /schedule/appointments/ endpoint accepts the following parameters:
+| Endpoint                                     | HTTP Method | Description                                                                               | Scope         |
+|----------------------------------------------|-------------|-------------------------------------------------------------------------------------------|---------------|
+| /schedule/appointments/{pd_appointment_uuid} | PUT         | Book appointment for an open slot. Post data contains patient attributes and description. | user_schedule |
 
-Field | Type | Description
------ | ---- | -----------
-appointment_type | {string} | The "appointment_type" used to identify a specific appointment procedure/category.
-start_date | {datetime} | The beginning date and UTC time of the appointment query, formatted as ISO8601.
-end_date | {datetime} | The ending date and UTC time of the appointment query, formatted as ISO8601.
-patient_uuid | {uuid} | The PokitDok unique identifier for the patient that has booked an appointment.
-pd_provider_uuid | {uuid} | The PokitDok unique identifier for the provider that has an open appointment slot.
-location | {geo-location} | The geo-location of the physical address where the provider that has an open appointment slot, formatted [latitude, longitude].
-        
-Endpoint | HTTP Method | Description | Scope
--------- | ----------- | ----------- | -----
-/schedule/appointments/{pd_appointment_uuid} | GET | Query for an open appointment slot or a booked appointment given a specific {pd_appointment_uuid}, the (PokitDok unique appointment identifier). | user_schedule
+| Endpoint                                     | HTTP Method | Description                     | Scope         |
+|----------------------------------------------|-------------|---------------------------------|---------------|
+| /schedule/appointments/{pd_appointment_uuid} | PUT         | Update appointment description. | user_schedule |
 
-        
-Endpoint | HTTP Method | Description | Scope
--------- | ----------- | ----------- | -----
-/schedule/appointments/{pd_appointment_uuid} | PUT | Book appointment for an open slot. Post data contains patient attributes and description. | user_schedule       
-
-Endpoint | HTTP Method | Description | Scope
--------- | ----------- | ----------- | -----
-/schedule/appointments/{pd_appointment_uuid} | PUT | Update appointment description. | user_schedule      
-
-        
-Field | Type | Description | Scope
------ | ---- | ----------- | -----
-/schedule/appointments/{pd_appointment_uuid} | DELETE | Cancel appointment given its {pd_appointment_uuid}. | user_schedule
+| Field                                        | Type   | Description                                         | Scope         |
+|----------------------------------------------|--------|-----------------------------------------------------|---------------|
+| /schedule/appointments/{pd_appointment_uuid} | DELETE | Cancel appointment given its {pd_appointment_uuid}. | user_schedule |

--- a/source/index.md
+++ b/source/index.md
@@ -30,6 +30,7 @@ includes:
   - eligibility
   - files
   - icdconvert
+  - identity
   - insuranceprices
   - mpc
   - payers


### PR DESCRIPTION
IDM Documentation:
- initial add to support /identity
- verbiage is lifted from Platform API workflows site
- supported query parameters are indexed health graph fields
- I still need to double-check markdown formatting locally. I'll post on the PR once that is confirmed

Scheduling Documentation:
- fixed some formatting issues where code examples were displayed within the "prose"