### PR TITLE
PLATFORM-3034: Adding address to /identity query parameter list

### DIFF
--- a/source/includes/_identity.md
+++ b/source/includes/_identity.md
@@ -207,6 +207,7 @@ All other parameters employ an exact matching strategy.
 - birth_date
 - email
 - member_id
+- *address*
 - *city*
 - state
 - zipcode


### PR DESCRIPTION
Updates to /identity documentation:
- added "address" as a search parameter