### PR TITLE
PLATFORM-2981

### DIFF
--- a/source/includes/_activities.md
+++ b/source/includes/_activities.md
@@ -10,6 +10,10 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/a
 pd.activities()
 ```
 
+```csharp
+client.activities();
+```
+
 > Example fetching information for a specific activity:
 
 ```shell
@@ -19,6 +23,10 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/a
 ```python
 #check on a specific activity
 pd.activities(activity_id='5362b5a064da150ef6f2526c')
+```
+
+```csharp
+client.activities("5362b5a064da150ef6f2526c");
 ```
 
 > Example to cancel an existing activity:

--- a/source/includes/_authorizations.md
+++ b/source/includes/_authorizations.md
@@ -90,6 +90,50 @@ pd.authorizations({
     "trading_partner_id": "MOCKPAYER"
 })
 ```
+
+```csharp
+client.authorizations(
+			new Dictionary<string, object> {
+				{"event", new Dictionary<string, object> {
+					{"category", "health_services_review"},
+					{"certification_type", "initial"},
+					{"delivery", new Dictionary<string, object> {
+						{"quantity", 1},
+						{"quantity_qualifier", "visits"}
+							}},
+						{"diagnoses", new Dictionary<string, object>[] {
+							new Dictionary<string, object> {
+								{"code", "789.00"},
+								{"date", "2014-10-01"}
+							}}},
+					{"place_of_service", "office"},
+					{"provider", new Dictionary<string, object> {
+							{"organization_name", "KELLY ULTRASOUND CENTER, LLC"},
+							{"npi", "1760779011"},
+							{"phone", "8642341234"}
+						}},
+					{"services", new Dictionary<string, object>[] {
+						new Dictionary<string, object> {
+							{"cpt_code", "76700"},
+							{"measurement", "unit"},
+							{"quantity", 1}
+						}}},
+					{"type", "diagnostic_imaging"}
+					}},
+				{"patient", new Dictionary<string, object> {
+						{"birth_date", "1970-01-01"},
+						{"first_name", "JANE"},
+						{"last_name", "DOE"},
+						{"id", "1234567890"}
+					}},
+				{"provider", new Dictionary<string, object> {
+						{"first_name", "JEROME"},
+						{"npi", "1467560003"},
+						{"last_name", "AYA-AY"}
+				}},
+				{"trading_partner_id", "MOCKPAYER"}
+			});
+```
 > Example authorizations response when the trading partner has authorized the request:
 
 ```

--- a/source/includes/_cashprices.md
+++ b/source/includes/_cashprices.md
@@ -8,6 +8,15 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/a
 ```python
 pd.cash_prices(zip_code='32218', cpt_code='87799')
 ```
+
+```csharp
+client.pricesCash(
+			new Dictionary<string, string> {
+				{ "zip_code", "30012" },
+				{ "cpt_code", "88142" }
+			});
+```
+
 *Available modes of operation: real-time*
 
 The Cash Prices endpoint allow access to our internal collection of pricing

--- a/source/includes/_claims.md
+++ b/source/includes/_claims.md
@@ -98,6 +98,51 @@ pd.claims({
     }
 })
 ```
+
+```csharp
+client.claims (
+			new Dictionary<string, object> {
+				{"transaction_code", "chargeable"},
+				{"trading_partner_id", "MOCKPAYER"},
+				{"billing_provider", new Dictionary<string, object> {
+						{"taxonomy_code", "207Q00000X"},
+						{"first_name", "Jerome"},
+						{"last_name", "Aya-Ay"},
+						{"npi", "1467560003"},
+						{"address", new Dictionary<string, object> {
+								{"address_lines", new string[] { "8311 WARREN H ABERNATHY HWY" }},
+								{"city", "SPARTANBURG"},
+								{"state", "SC"},
+								{"zipcode", "29301"}
+							}},
+						{"tax_id", "123456789"}
+					}},
+				{"subscriber", new Dictionary<string, object> {
+						{"first_name", "Jane"},
+						{"last_name", "Doe"},
+						{"member_id", "W000000000"},
+						{"address", new Dictionary<string, object> {
+								{"address_lines", new string[] { "123 N MAIN ST" }},
+								{"city", "SPARTANBURG"},
+								{"state", "SC"},
+								{"zipcode", "29301"}
+							}},
+						{"birth_date", "1970-01-01"},
+						{"gender", "female"}
+					}},
+				{"claim", new Dictionary<string, object> {
+						{"total_charge_amount", 60.0},
+						{"service_lines", new object[] {
+								new Dictionary<string, object> {
+									{"procedure_code", "99213"},
+									{"charge_amount", 60.0},
+									{"unit_count", 1.0},
+									{"diagnosis_codes", new string[] { "487.1" }},
+									{"service_date", "2014-06-01"}
+					}}}}}
+			});
+```
+
 > Sample Claims request where the patient is not the subscriber:
 
 ```shell

--- a/source/includes/_claimstatus.md
+++ b/source/includes/_claimstatus.md
@@ -37,6 +37,25 @@ pd.claims_status({
 })
 ```
 
+```csharp
+client.claimsStatus(
+			new Dictionary<string, object> {
+				{"patient", new Dictionary<string, object> {
+						{"id", "W000000000"},
+						{"birth_date", "1970-01-01"},
+						{"first_name", "Jane"},
+						{"last_name", "Doe"}
+					}},
+				{"provider", new Dictionary<string, object> {
+						{"npi", "1467560003"},
+						{"last_name", "AYA-AY"},
+						{"first_name", "JEROME"}
+					}},
+				{"service_date", "2014-01-01"},
+				{"trading_partner_id", "MOCKPAYER"}
+			});
+```
+
 > Example claim status request when the patient is not the subscriber on the insurance policy:
 
 ```shell

--- a/source/includes/_common.md
+++ b/source/includes/_common.md
@@ -1,5 +1,33 @@
 # Common To All Endpoints
 
+## Client generic request handlers
+To guarantee clients have reliable access to the newest PokitDok endpoints,
+a generic request handler is built into most clients. This allows for the sending
+of files and JSON payloads to any PokitDok endpoint for any given CRUD operation.
+
+> Example calls using the generic request handler
+
+
+```csharp
+client.request("/eligibility/", "POST", ExampleRequests.EligibilityRequest);
+```
+
+```csharp
+client.request("/identity/4d04d8dc-3d0b-4ea1-8add-4dbc9619e1ae", "PUT", ExampleRequests.CreateIdentityRequest);
+```
+
+> Example call sending a file using the generic request handler
+
+```csharp
+ client.request(
+            "/enrollment/snapshot",
+            "../../tests/files/acme_inc_add_subscriber.834",
+            "file",
+            "application/EDI-X12",
+            postData
+            );
+```
+
 ## Collection Parameters
 The below query parameters can be added to collection requests from endpoints
 to limit and page through the returned list of results. Singular endpoint
@@ -269,3 +297,5 @@ limit period to renew and then make the API call again.
 ### Required information missing or invalid
 You may encounter errors like this when required information is omitted from an
 API call. Simply supply the appropriate information on the next API call to resolve.
+
+>

--- a/source/includes/_eligibility.md
+++ b/source/includes/_eligibility.md
@@ -35,7 +35,7 @@ pd.eligibility({
 })
 ```
 
-```
+```csharp
  client.eligibility (
 			new Dictionary<string, object> {
 			 	{"member", new Dictionary<string, object> {

--- a/source/includes/_eligibility.md
+++ b/source/includes/_eligibility.md
@@ -35,6 +35,25 @@ pd.eligibility({
 })
 ```
 
+```
+ client.eligibility (
+			new Dictionary<string, object> {
+			 	{"member", new Dictionary<string, object> {
+					{"id", "W000000000"},
+					{"birth_date", "1970-01-01"},
+					{"first_name", "Jane"},
+					{"last_name", "Doe"}
+					}},
+				{"provider", new Dictionary<string, object> {
+					{"npi", "1467560003"},
+					{"last_name", "AYA-AY"},
+					{"first_name", "JEROME"}
+					}},
+				{"service_types", new string[] { "health_benefit_plan_coverage" }},
+				{"trading_partner_id", "MOCKPAYER"}
+		});
+```
+
 > Example eligibility request when operating on behalf of a member and a specific provider is not yet known:
 
 ```shell

--- a/source/includes/_enrollment.md
+++ b/source/includes/_enrollment.md
@@ -180,6 +180,88 @@ pd.enrollment({
     "trading_partner_id": "MOCKPAYER",
 })
 ```
+
+```csharp
+ client.enrollment(
+        new Dictionary<string, object> {
+        { "action", "Change"},
+         {"dependents", new List<string> { } },
+         {"master_policy_number", "ABCD012354"},
+         { "payer", new Dictionary<string, object> {
+                { "tax_id", "654456654" }
+             }
+         },
+         {   "purpose", "Original"},
+         {   "sponsor", new Dictionary<string, object> {
+                {"tax_id", "999888777" }
+         } },
+        { "subscriber", new Dictionary<string, object> {
+                { "address", new Dictionary<string, object> {
+                { "city", "CAMP HILL"},
+                { "county", "CUMBERLAND"},
+                { "line", "100 MARKET ST"},
+                { "line2", "APT 3G"},
+                { "postal_code", "17011"},
+                { "state", "PA" }
+                }},
+                { "benefit_status", "Active"},
+                { "benefits", new List<Dictionary<string, object>> {
+                                new Dictionary<string, object> {
+                                    { "begin_date", "2015-01-01"},
+                                    { "benefit_type", "Health"},
+                                    { "coordination_of_benefits", new List<Dictionary<string, object>> {
+                                        new Dictionary<string, object> {
+                                                { "group_or_policy_number", "890111"},
+                                                { "payer_responsibility", "Primary"},
+                                                { "status", "Unknown" }
+                                            }
+                                        }
+                                    },
+                                    { "late_enrollment", false},
+                                    { "maintenance_type", "Addition" }
+                                }, // benefits[0]
+                                new Dictionary<string, object> {
+                                    { "begin_date", "2015-01-01"},
+                                    { "benefit_type", "Dental"},
+                                    { "late_enrollment", false},
+                                    { "maintenance_type", "Addition" }
+                                    },
+                                new Dictionary<string, object> {
+                                    { "begin_date", "2015-01-01"},
+                                    { "benefit_type", "Vision"},
+                                    { "late_enrollment", false},
+                                    { "maintenance_type", "Addition" }
+                                    }} // End list
+                    },
+                    { "birth_date", "1940-01-01"},
+                    { "contacts", new List<Dictionary<string, object>> {
+                            new Dictionary<string, object> {
+                                { "communication_number2", "7172341240"},
+                                { "communication_type2", "Work Phone Number"},
+                                { "primary_communication_number", "7172343334"},
+                                { "primary_communication_type", "Home Phone Number" }
+                                }
+                    } },
+                    { "eligibility_begin_date", "2014-01-01"},
+                    { "employment_status", "Full-time"},
+                    { "first_name", "JOHN"},
+                    { "gender", "Male"},
+                    { "group_or_policy_number", "123456001"},
+                    { "handicapped", false},
+                    { "last_name", "DOE"},
+                    { "maintenance_reason", "Active"},
+                    { "maintenance_type", "Addition"},
+                    { "member_id", "123456789"},
+                    { "middle_name", "P"},
+                    { "relationship", "Self"},
+                    { "ssn", "123456789"},
+                    { "subscriber_number", "123456789"},
+                    { "substance_abuse", false},
+                    { "tobacco_use", false
+                }} },
+                { "trading_partner_id", "MOCKPAYER" }
+        });
+```
 >Example change request to add a dependent due to a qualifying life event. (Health)
 
 ```shell

--- a/source/includes/_files.md
+++ b/source/includes/_files.md
@@ -9,6 +9,13 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" -XPOST -F file=@eligibility_req
 pd.files('MOCKPAYER', 'eligibility_requests.270')
 ```
 
+```csharp
+client.files(
+			"MOCKPAYER",
+			"../../tests/files/general-physician-office-visit.270"
+		);
+```
+
 *Available modes of operation: batch/async*
 
 All endpoints that result in the transmission of X12 transaction sets to our trading partners accept parameters via a JSON representation. This keeps applications developers from having to interact directly with raw X12 files.  The Files endpoint, however, accepts raw ASC X12 EDI files for transmission to our trading partners.

--- a/source/includes/_icdconvert.md
+++ b/source/includes/_icdconvert.md
@@ -10,6 +10,10 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/a
 pd.icd_convert('250.12')
 ```
 
+```csharp
+client.icdConvert("250.12");
+```
+
 > Example ICD convert response
 
 ```

--- a/source/includes/_identity.md
+++ b/source/includes/_identity.md
@@ -64,6 +64,10 @@ pd.create_identity({
 })
 ```
 
+```csharp
+client.createIdentity(ExampleRequests.CreateIdentityRequest);
+```
+
 > Example updating an identity resource
 
 ```shell
@@ -136,6 +140,11 @@ curl -s -H "Authorization: Bearer $ACCESS_TOKEN" "https://platform.pokitdok.com/
 ```python
 pd.identity("881bc095-2068-43cb-9783-cce630364122")
 ```
+
+```csharp
+client.identity("4d04d8dc-3d0b-4ea1-8add-4dbc9619e1ae");
+```
+
 
 > Query for one or more identity resources using parameters
 

--- a/source/includes/_insuranceprices.md
+++ b/source/includes/_insuranceprices.md
@@ -10,6 +10,14 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/a
 pd.insurance_prices(zip_code='32218', cpt_code='87799')
 ```
 
+```csharp
+client.pricesInsurance(
+			new Dictionary<string, string> {
+				{ "zip_code", "32218" },
+				{ "cpt_code", "87799" }
+			});
+```
+
 *Available modes of operation: real-time*
 
 The Insurance Prices endpoint allows access to our collection of insurance

--- a/source/includes/_mpc.md
+++ b/source/includes/_mpc.md
@@ -9,6 +9,11 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/a
 pd.mpc(code='99213')
 ```
 
+```csharp
+client.medicalProcedureCode("99211");
+```
+
+
 > curl example searching medical procedure information by consumer friendly name
 
 ```shell
@@ -17,6 +22,13 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/a
 
 ```python
 pd.mpc(name='office')
+```
+
+```csharp
+client.medicalProcedureCode(
+            new Dictionary<string, string> {
+                {"name", "Established patient office or other outpatient visit, typically 15 minutes"}
+            });
 ```
 
 *Available modes of operation: real-time only*

--- a/source/includes/_plans.md
+++ b/source/includes/_plans.md
@@ -9,6 +9,11 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/a
 pd.plans()
 ```
 
+```csharp
+client.plans();
+```
+
+
 > example fetching information for plans in Texas:
 
 ```shell
@@ -19,6 +24,14 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/a
 pd.plans(state='TX')
 ```
 
+```csharp
+client.plans(
+			new Dictionary<string, string> {
+				{ "state", "TX" }
+			}
+		);
+```
+
 > example fetching information for PPO plans in South Carolina:
 
 ```shell
@@ -27,6 +40,15 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/a
 
 ```python
 pd.plans(state='SC', plan_type='PPO')
+```
+
+```csharp
+client.plans(
+			new Dictionary<string, string> {
+				{ "state", "TX" },
+				{ "plan_type", "PPO" }
+			}
+		);
 ```
 *Available modes of operation: real-time*
 

--- a/source/includes/_providers.md
+++ b/source/includes/_providers.md
@@ -9,6 +9,10 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/a
 pd.providers(npi='1467560003')
 ```
 
+```csharp
+client.providers("1467560003");
+```
+
 > Example searching providers by zipcode and specialty:
 
 ```shell
@@ -18,6 +22,16 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/a
 ```python
 pd.providers(zipcode='29307', specialty='rheumatology', radius='20mi')
 ```
+
+```csharp
+ client.providers(
+			new Dictionary<string, string> {
+				{ "zipcode", "29307" },
+				{ "specialty", "rheumatology" },
+				{ "radius", "20mi" }
+		});
+```
+
 
 *Available modes of operation: real-time only*
 

--- a/source/includes/_referrals.md
+++ b/source/includes/_referrals.md
@@ -80,6 +80,45 @@ pd.referrals({
 })
 ```
 
+```csharp
+ client.referrals(
+			new Dictionary<string, object> {
+				{"event", new Dictionary<string, object> {
+						{"category", "specialty_care_review"},
+						{"certification_type", "initial"},
+						{"delivery", new Dictionary<string, object> {
+							{"quantity", 1},
+							{"quantity_qualifier", "visits"}
+							}},
+						{"diagnoses", new Dictionary<string, string>[] {
+							new Dictionary<string, string> {
+								{"code", "384.20"},
+								{"date", "2014-09-30"}
+							}}},
+						{"place_of_service", "office"},
+						{"provider", new Dictionary<string, string> {
+							{"first_name", "JOHN"},
+							{"npi", "1154387751"},
+							{"last_name", "FOSTER"},
+							{"phone", "8645822900"}
+							}},
+						{"type", "consultation"},
+					}},
+				{"patient", new Dictionary<string, string> {
+						{"birth_date", "1970-01-01"},
+						{"first_name", "JANE"},
+						{"last_name", "DOE"},
+						{"id", "1234567890"}
+					}},
+				{"provider", new Dictionary<string, string> {
+						{"first_name", "CHRISTINA"},
+						{"last_name", "BERTOLAMI"},
+						{"npi", "1619131232"}
+					}},
+				{"trading_partner_id", "MOCKPAYER"}
+			});
+```
+
 > Example referrals response when the trading partner has authorized the request:
 
 ```

--- a/source/includes/_scheduling.md
+++ b/source/includes/_scheduling.md
@@ -11,6 +11,10 @@ curl -s -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/a
 pd.schedulers()
 ```
 
+```csharp
+client.schedulers();
+```
+
 > Response:
 
 ```
@@ -43,6 +47,11 @@ curl -s -H "Authorization: Bearer $ACCESS_TOKEN" "https://platform.pokitdok.com/
 pd.schedulers(scheduler_uuid='967d207f-b024-41cc-8cac-89575a1f6fef')
 ```
 
+```csharp
+client.schedulers("967d207f-b024-41cc-8cac-89575a1f6fef");
+```
+
+
 > Response:
 
 ```
@@ -63,6 +72,10 @@ curl -s -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/a
 
 ```python
 pd.appointment_types()
+```
+
+```csharp
+client.appointmentTypes();
 ```
 
 > Response:
@@ -96,6 +109,10 @@ curl -s -H "Authorization: Bearer $ACCESS_TOKEN" "https://platform.pokitdok.com/
 pd.appointment_types(appointment_type_uuid='ef987693-0a19-447f-814d-f8f3abbf4860')
 ```
 
+```csharp
+client.appointmentTypes("a3a45130-4adb-4d2c-9411-85a9d9ac4aa2");
+```
+
 > Response:
 
 ```
@@ -126,6 +143,18 @@ pd.post('/schedule/patient/', data={
     "pd_provider_uuid": "b691b7f9-bfa8-486d-a689-214ae47ea6f8",
     "location": [32.788110, -79.932364]
 })
+```
+
+```csharp
+ client.appointments(
+            new Dictionary<string, string> {
+                {"appointment_type", "SS1"},
+                {"start_date", "2015-01-14T08:00:00"},
+                {"end_date", "2015-01-16T17:00:00"},
+                {"patient_uuid", "8ae236ff-9ccc-44b0-8717-42653cd719d0"}
+            });
+```
+
 ```
 
 > Response:
@@ -164,6 +193,21 @@ pd.schedule_slots({
 })
 ```
 
+```csharp
+ client.bookAppointment(
+            "ef987691-0a19-447f-814d-f8f3abbf4859",
+            new Dictionary<string, object> {
+                {"patient", new Dictionary<string, object> {
+                    {"uuid", "500ef469-2767-4901-b705-425e9b6f7f83"},
+                    {"email", "john@johndoe.com"},
+                    {"phone", "800-555-1212"},
+                    {"birth_date", "1970-01-01"},
+                    {"first_name", "John"},
+                    {"last_name", "Doe"},
+                    {"member_id", "M000001"}}}
+            });
+```
+
 > Response:
 
 ```
@@ -199,6 +243,15 @@ pd.appointments(appointment_type='SS1', start_date='2015-01-14T08:00:00',
     end_date='2015-01-16T17:00:00', patient_uuid='8ae236ff-9ccc-44b0-8717-42653cd719d0')
 ```
 
+```csharp
+client.appointments(
+            new Dictionary<string, string> {
+                {"appointment_type", "SS1"},
+                {"start_date", "2015-01-14T08:00:00"},
+                {"end_date", "2015-01-16T17:00:00"},
+                {"patient_uuid", "8ae236ff-9ccc-44b0-8717-42653cd719d0"}
+            });
+```
 > Response:
 
 ```
@@ -232,6 +285,10 @@ curl -s -H "Authorization: Bearer $ACCESS_TOKEN" "https://platform.pokitdok.com/
 
 ```python
 pd.appointments(appointment_uuid='ef987691-0a19-447f-814d-f8f3abbf4859')
+```
+
+```csharp
+client.appointments("bf8440b1-fd20-4994-bb28-e3981833e796");
 ```
 
 > Response:
@@ -347,6 +404,21 @@ curl -i -XDELETE -H "Authorization: Bearer $ACCESS_TOKEN"  "https://platform.pok
 pd.cancel_appointment('ef987691-0a19-447f-814d-f8f3abbf4859')
 ```
 
+```csharp
+client.cancelAppointment("ef987691-0a19-447f-814d-f8f3abbf4859");
+```
+
+> Example updating an appointment with a given uuid
+
+```csharp
+ client.updateAppointment(
+            "ef987691-0a19-447f-814d-f8f3abbf4859",
+            new Dictionary<string, object> {
+                {"description", "Welcome to M0d3rN Healthcare"}
+            });
+```
+
+
 *Available modes of operation: real-time*
 
 The PokitDok Scheduling API performs schedule aggregation to multiple third party scheduling
@@ -424,6 +496,7 @@ Available Scheduling Endpoints:
 | Endpoint                                     | HTTP Method | Description                     | Scope         |
 |:---------------------------------------------|:------------|:--------------------------------|:--------------|
 | /schedule/appointments/{pd_appointment_uuid} | PUT         | Update appointment description. | user_schedule |
+
 
 | Field                                        | Type   | Description                                         | Scope         |
 |:---------------------------------------------|:-------|:----------------------------------------------------|:--------------|

--- a/source/includes/_tradingpartners.md
+++ b/source/includes/_tradingpartners.md
@@ -9,6 +9,12 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/a
 pd.trading_partners()
 ```
 
+```csharp
+client.tradingPartners();
+```
+
+
+
 > Example fetching information for a specific trading partner
 
 ```shell
@@ -18,6 +24,11 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/a
 ```python
 pd.trading_partners('aetna')
 ```
+
+```csharp
+client.tradingPartners("MOCKPAYER");
+```
+
 *Available modes of operation: real-time*
 
 The Trading Partners endpoint provides access to the collection of PokitDok's trading


### PR DESCRIPTION
API documentation updates to provide examples for using the csharp client. We didn't really have any examples before. 

I also added a section in the documentation for `Generic` request handlers. Currently only the csharp client has an example usage. 