### PR TITLE
PLATFORM-3194 update Claims doc for service_end_date

### DIFF
--- a/source/includes/_claims.md
+++ b/source/includes/_claims.md
@@ -43,8 +43,7 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/j
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01",
-                "service_end_date": "2014-07-01"
+                "service_date": "2014-06-01"
             }
         ]
     }
@@ -93,8 +92,7 @@ pd.claims({
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01",
-                "service_end_date": "2014-07-01"
+                "service_date": "2014-06-01"
             }
         ]
     }
@@ -140,8 +138,7 @@ client.claims (
 									{"charge_amount", 60.0},
 									{"unit_count", 1.0},
 									{"diagnosis_codes", new string[] { "487.1" }},
-									{"service_date", "2014-06-01"},
-									{"service_end_date": "2014-07-01"}
+									{"service_date", "2014-06-01"}
 					}}}}}
 			});
 ```
@@ -204,8 +201,7 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/j
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01",
-                "service_end_date": "2014-07-01"
+                "service_date": "2014-06-01"
             }
         ]
     }
@@ -268,8 +264,7 @@ pd.claims({
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01",
-                "service_end_date": "2014-07-01"
+                "service_date": "2014-06-01"
             }
         ]
     }
@@ -326,8 +321,7 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/j
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01",
-                "service_end_date": "2014-07-01"
+                "service_date": "2014-06-01"
             }
         ]
     }
@@ -381,8 +375,7 @@ pd.claims({
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01",
-                "service_end_date": "2014-07-01"
+                "service_date": "2014-06-01"
             }
         ]
     }
@@ -436,8 +429,7 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/j
                 "diagnosis_codes": [
                     "701.9"
                 ],
-                "service_date": "2014-11-24",
-                "service_end_date": "2014-12-24"
+                "service_date": "2014-11-24"
             }
         ]
     }
@@ -488,8 +480,7 @@ pd.claims({
                 "diagnosis_codes": [
                     "701.9"
                 ],
-                "service_date": "2014-11-24",
-                "service_end_date": "2014-12-24"
+                "service_date": "2014-11-24"
             }
         ]
     }
@@ -543,8 +534,7 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/j
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01",
-                "service_end_date": "2014-07-01"
+                "service_date": "2014-06-01"
             }
         ]
     }
@@ -594,8 +584,7 @@ pd.claims({
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01",
-                "service_end_date": "2014-07-01"
+                "service_date": "2014-06-01"
             }
         ]
     }
@@ -647,8 +636,7 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/j
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01",
-                "service_end_date": "2014-07-01"
+                "service_date": "2014-06-01"
             }
         ]
     }
@@ -698,8 +686,7 @@ pd.claims({
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01",
-                "service_end_date": "2014-07-01"
+                "service_date": "2014-06-01"
             }
         ]
     }
@@ -764,7 +751,6 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/j
         "procedure_code": "Q5002",
         "revenue_code": "0651",
         "service_date": "2015-03-01",
-        "service_end_date": "2015-04-01",
         "unit_count": "31",
         "unit_type": "days",
         "provider_control_number": "6750000"
@@ -850,7 +836,6 @@ pd.claims({
         "procedure_code": "Q5002",
         "revenue_code": "0651",
         "service_date": "2015-03-01",
-        "service_end_date": "2015-04-01",
         "unit_count": "31",
         "unit_type": "days",
         "provider_control_number": "6750000"
@@ -931,8 +916,7 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/j
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01",
-                "service_end_date": "2014-07-01"
+                "service_date": "2014-06-01"
             }
         ]
     }
@@ -985,8 +969,7 @@ pd.claims({
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01",
-                "service_end_date": "2014-07-01"
+                "service_date": "2014-06-01"
             }
         ]
     }
@@ -1045,8 +1028,7 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/j
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01",
-                "service_end_date": "2014-07-01"
+                "service_date": "2014-06-01"
             }
         ]
     }
@@ -1102,12 +1084,63 @@ pd.claims({
                 "diagnosis_codes": [
                     "487.1"
                 ],
+                "service_date": "2014-06-01"
+            }
+        ]
+    }
+})
+```
+
+> Sample Claims request for sending service date range, using service date and service end date:
+
+```shell
+curl -i -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json" -XPOST -d '{
+    "transaction_code": "chargeable",
+    "trading_partner_id": "MOCKPAYER",
+    "billing_provider": {
+        "taxonomy_code": "207Q00000X",
+        "first_name": "Jerome",
+        "last_name": "Aya-Ay",
+        "npi": "1467560003",
+        "address": {
+            "address_lines": [
+                "8311 WARREN H ABERNATHY HWY"
+            ],
+            "city": "SPARTANBURG",
+            "state": "SC",
+            "zipcode": "29301"
+        },
+        "tax_id": "123456789"
+    },
+    "subscriber": {
+        "first_name": "Jane",
+        "last_name": "Doe",
+        "member_id": "W000000000",
+        "address": {
+            "address_lines": ["123 N MAIN ST"],
+            "city": "SPARTANBURG",
+            "state": "SC",
+            "zipcode": "29301"
+        },
+        "birth_date": "1970-01-01",
+        "gender": "female"
+    },
+    "claim": {
+        "total_charge_amount": 60.0,
+        "service_lines": [
+            {
+                "procedure_code": "99213",
+                "charge_amount": 60.0,
+                "unit_count": 1.0,
+                "diagnosis_codes": [
+                    "487.1"
+                ],
                 "service_date": "2014-06-01",
                 "service_end_date": "2014-07-01"
             }
         ]
     }
-})
+}` https://platform.pokitdok.com/api/v4/claims/
 ```
 
 *Available modes of operation: batch/async*
@@ -1189,7 +1222,7 @@ The /claims/ endpoint accepts the following parameters:
 | claim.service_lines.provider_control_number   | The provider's control number.                                                                                                                                                                                                                                                        |                                                    |
 | claim.service_lines.revenue_code              | (_Institutional claim specific_) The revenue code related to this service. UB-04 field: *42. Revenue Code*                                                                                                                                                                            |                                                    |
 | claim.service_lines.service_date              | The date the service was performed.                                                                                                                                                                                                                                                   | 24a: Date(s) of service (from)                     |
-| claim.service_lines.service_end_date          | The end date for the service. Use this to utilize a date range for the service date. Leave blank for single date of service.                                                                                                                                                          | 24a: Date(s) of service (to)                       |
+| claim.service_lines.service_end_date          | Optional: The end date for the service. Use this to utilize a date range for the service date.                                                                                                                                                         | 24a: Date(s) of service (to)                       |
 | claim.service_lines.unit_count                | Number of units of this service. (e.g. 1.0)                                                                                                                                                                                                                                           | 24g: Days or Units                                 |
 | claim.service_lines.unit_type                 | The type of unit being described for this particular service's unit count. Possible values include: units, days                                                                                                                                                                       |                                                    |
 | claim.total_charge_amount                     | The total amount charged/billed for the claim. (e.g. 100.00)                                                                                                                                                                                                                          | 28: Total Charge                                   |

--- a/source/includes/_claims.md
+++ b/source/includes/_claims.md
@@ -43,7 +43,8 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/j
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01"
+                "service_date": "2014-06-01",
+                "service_end_date": "2014-07-01"
             }
         ]
     }
@@ -92,7 +93,8 @@ pd.claims({
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01"
+                "service_date": "2014-06-01",
+                "service_end_date": "2014-07-01"
             }
         ]
     }
@@ -138,7 +140,8 @@ client.claims (
 									{"charge_amount", 60.0},
 									{"unit_count", 1.0},
 									{"diagnosis_codes", new string[] { "487.1" }},
-									{"service_date", "2014-06-01"}
+									{"service_date", "2014-06-01"},
+									{"service_end_date": "2014-07-01"}
 					}}}}}
 			});
 ```
@@ -201,7 +204,8 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/j
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01"
+                "service_date": "2014-06-01",
+                "service_end_date": "2014-07-01"
             }
         ]
     }
@@ -264,7 +268,8 @@ pd.claims({
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01"
+                "service_date": "2014-06-01",
+                "service_end_date": "2014-07-01"
             }
         ]
     }
@@ -321,7 +326,8 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/j
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01"
+                "service_date": "2014-06-01",
+                "service_end_date": "2014-07-01"
             }
         ]
     }
@@ -375,7 +381,8 @@ pd.claims({
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01"
+                "service_date": "2014-06-01",
+                "service_end_date": "2014-07-01"
             }
         ]
     }
@@ -429,7 +436,8 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/j
                 "diagnosis_codes": [
                     "701.9"
                 ],
-                "service_date": "2014-11-24"
+                "service_date": "2014-11-24",
+                "service_end_date": "2014-12-24"
             }
         ]
     }
@@ -480,7 +488,8 @@ pd.claims({
                 "diagnosis_codes": [
                     "701.9"
                 ],
-                "service_date": "2014-11-24"
+                "service_date": "2014-11-24",
+                "service_end_date": "2014-12-24"
             }
         ]
     }
@@ -534,7 +543,8 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/j
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01"
+                "service_date": "2014-06-01",
+                "service_end_date": "2014-07-01"
             }
         ]
     }
@@ -584,7 +594,8 @@ pd.claims({
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01"
+                "service_date": "2014-06-01",
+                "service_end_date": "2014-07-01"
             }
         ]
     }
@@ -636,7 +647,8 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/j
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01"
+                "service_date": "2014-06-01",
+                "service_end_date": "2014-07-01"
             }
         ]
     }
@@ -686,7 +698,8 @@ pd.claims({
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01"
+                "service_date": "2014-06-01",
+                "service_end_date": "2014-07-01"
             }
         ]
     }
@@ -751,6 +764,7 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/j
         "procedure_code": "Q5002",
         "revenue_code": "0651",
         "service_date": "2015-03-01",
+        "service_end_date": "2015-04-01",
         "unit_count": "31",
         "unit_type": "days",
         "provider_control_number": "6750000"
@@ -836,6 +850,7 @@ pd.claims({
         "procedure_code": "Q5002",
         "revenue_code": "0651",
         "service_date": "2015-03-01",
+        "service_end_date": "2015-04-01",
         "unit_count": "31",
         "unit_type": "days",
         "provider_control_number": "6750000"
@@ -916,7 +931,8 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/j
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01"
+                "service_date": "2014-06-01",
+                "service_end_date": "2014-07-01"
             }
         ]
     }
@@ -969,7 +985,8 @@ pd.claims({
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01"
+                "service_date": "2014-06-01",
+                "service_end_date": "2014-07-01"
             }
         ]
     }
@@ -1028,7 +1045,8 @@ curl -i -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/j
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01"
+                "service_date": "2014-06-01",
+                "service_end_date": "2014-07-01"
             }
         ]
     }
@@ -1084,7 +1102,8 @@ pd.claims({
                 "diagnosis_codes": [
                     "487.1"
                 ],
-                "service_date": "2014-06-01"
+                "service_date": "2014-06-01",
+                "service_end_date": "2014-07-01"
             }
         ]
     }
@@ -1169,7 +1188,8 @@ The /claims/ endpoint accepts the following parameters:
 | claim.service_lines.procedure_modifier_codes  | Optional: List of modifier codes for the specified procedure. (e.g. ["GT"])                                                                                                                                                                                                           | 24d: Procedures, Services, or Supplies             |
 | claim.service_lines.provider_control_number   | The provider's control number.                                                                                                                                                                                                                                                        |                                                    |
 | claim.service_lines.revenue_code              | (_Institutional claim specific_) The revenue code related to this service. UB-04 field: *42. Revenue Code*                                                                                                                                                                            |                                                    |
-| claim.service_lines.service_date              | The date the service was performed.                                                                                                                                                                                                                                                   | 24a: Date(s) of service (from, to)                 |
+| claim.service_lines.service_date              | The date the service was performed.                                                                                                                                                                                                                                                   | 24a: Date(s) of service (from)                     |
+| claim.service_lines.service_end_date          | The end date for the service. Use this to utilize a date range for the service date. Leave blank for single date of service.                                                                                                                                                          | 24a: Date(s) of service (to)                       |
 | claim.service_lines.unit_count                | Number of units of this service. (e.g. 1.0)                                                                                                                                                                                                                                           | 24g: Days or Units                                 |
 | claim.service_lines.unit_type                 | The type of unit being described for this particular service's unit count. Possible values include: units, days                                                                                                                                                                       |                                                    |
 | claim.total_charge_amount                     | The total amount charged/billed for the claim. (e.g. 100.00)                                                                                                                                                                                                                          | 28: Total Charge                                   |


### PR DESCRIPTION
Update to claims api doc, to include service_end_date in sample requests. Updated the CMS reference for service_date to more pointedly map to the 'from' and the service_end_date to map to the 'to' date, if entering a date range.