### PR TITLE
PLATFORM-3256: Update cash API documentation

### DIFF
--- a/source/includes/_cashprices.md
+++ b/source/includes/_cashprices.md
@@ -43,12 +43,14 @@ The /prices/cash endpoint accepts the following parameters:
 
 The /prices/cash response contains the following fields:
 
-| Field                      | Type      | Description                                                               |
-|:---------------------------|:----------|:--------------------------------------------------------------------------|
-| amounts.average_price      | {decimal} | The average cash price for the procedure                                  |
-| amounts.cpt_code           | {string}  | The CPT code of the procedure                                             |
-| amounts.geo_zip_area       | {string}  | The three character zip code tabulation area code                         |
-| amounts.high_price         | {decimal} | The maximum price for the procedure                                       |
-| amounts.low_price          | {decimal} | The lowest price for the procedure                                        |
-| amounts.median_price       | {decimal} | The median price for the procedure                                        |
-| amounts.standard_deviation | {decimal} | The standard deviation, or variation measure, of prices for the procedure |
+| Field                  | Type      | Description                                                               |
+|:-----------------------|:----------|:--------------------------------------------------------------------------|
+| average_price          | {decimal} | The average cash price for the procedure                                  |
+| cpt_code               | {string}  | The CPT code of the procedure                                             |
+| pokitdok_procedure_urn | {string}  | A URN that uniquely identifies the procedure                              |
+| procedure_description  | {string}  | The description of the procedure                                          |
+| geo_zip_area           | {string}  | The three character zip code tabulation area code                         |
+| high_price             | {decimal} | The maximum price for the procedure                                       |
+| low_price              | {decimal} | The lowest price for the procedure                                        |
+| median_price           | {decimal} | The median price for the procedure                                        |
+| standard_deviation     | {decimal} | The standard deviation, or variation measure, of prices for the procedure |


### PR DESCRIPTION
Added the pokitdok_procedure_urn and procedure_description fields to the
documentation for the cash price API, as well as corrected the other
field names.