### PR TITLE
PLATFORM-3258: Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:trusty
 
+RUN apt-get -yq install software-properties-common
+RUN apt-add-repository ppa:brightbox/ruby-ng
 RUN apt-get update
-RUN apt-get install -yq ruby ruby-dev build-essential git
+RUN apt-get install -yq ruby2.2 ruby2.2-dev build-essential git zlib1g-dev liblzma-dev
 RUN gem install --no-ri --no-rdoc bundler
 ADD Gemfile /app/Gemfile
 ADD Gemfile.lock /app/Gemfile.lock


### PR DESCRIPTION
Updated the Dockerfile so that it installs the right version of ruby as
well as installing the dependencies for nokogiri.