### PR TITLE
UTEST-1942: Fixed duplicate messaging

### DIFF
--- a/source/includes/_common.md
+++ b/source/includes/_common.md
@@ -91,23 +91,11 @@ See cURL example.
 See cURL example.
 ```
 
-```javascript
-See cURL example.
-```
-
 ```csharp
 See cURL example.
 ```
 
 ```java
-See cURL example.
-```
-
-```haskell
-See cURL example.
-```
-
-```lua
 See cURL example.
 ```
 
@@ -133,23 +121,11 @@ See cURL example.
 See cURL example.
 ```
 
-```javascript
-See cURL example.
-```
-
 ```csharp
 See cURL example.
 ```
 
 ```java
-See cURL example.
-```
-
-```haskell
-See cURL example.
-```
-
-```lua
 See cURL example.
 ```
 
@@ -176,23 +152,11 @@ See cURL example.
 See cURL example.
 ```
 
-```javascript
-See cURL example.
-```
-
 ```csharp
 See cURL example.
 ```
 
 ```java
-See cURL example.
-```
-
-```haskell
-See cURL example.
-```
-
-```lua
 See cURL example.
 ```
 
@@ -246,23 +210,11 @@ See cURL example.
 See cURL example.
 ```
 
-```javascript
-See cURL example.
-```
-
 ```csharp
 See cURL example.
 ```
 
 ```java
-See cURL example.
-```
-
-```haskell
-See cURL example.
-```
-
-```lua
 See cURL example.
 ```
 


### PR DESCRIPTION
- Removed code samples for languages that don't have tabs anymore which fixed duplicate "See cURL example" text