### PR TITLE
ENTERPRISE-315 : Updates to the Client Library Documentation Section

### DIFF
--- a/source/includes/_clientlibraries.md
+++ b/source/includes/_clientlibraries.md
@@ -13,8 +13,6 @@ These libraries are hosted on
 | Java                | [pokitdok-java](https://github.com/pokitdok/pokitdok-java)       |
 | C#                  | [pokitdok-csharp](https://github.com/pokitdok/pokitdok-csharp)   |
 | NodeJS              | [pokitdok-nodejs](https://github.com/pokitdok/pokitdok-nodejs)   |
-| Lua                 | [pokitdok-lua](https://github.com/pokitdok/pokitdok-lua)         |
-| Haskell             | [pokitdok-haskell](https://github.com/pokitdok/pokitdok-haskell) |
 
 The following sections go into further detail on the underlying details of
 connecting directly to the PokitDok API. This is of use if you're implementing


### PR DESCRIPTION
Completion of [ENTERPRISE-315](https://pokitdok.atlassian.net/browse/ENTERPRISE-315) ticket which entailed removing dead links of the Lua and Haskell client libraries. 