### PR TITLE
ENTERPRISE-393: Adding client_id to docs

### DIFF
--- a/source/includes/_authorizations.md
+++ b/source/includes/_authorizations.md
@@ -235,6 +235,7 @@ pd.authorizations(query);
 
 ```json
 {
+    "client_id": "<client_id>",
     "event": {
         "category": "health_services_review",
         "certification_type": "initial",
@@ -285,6 +286,7 @@ pd.authorizations(query);
 
 ```
 {
+    "client_id": "<client_id>",
     "patient": {
         "birth_date": "1970-02-02",
         "first_name": "Jane",
@@ -344,6 +346,7 @@ The /authorizations/ endpoint uses the same object for both its parameters and r
 
 | Field                             | Description                                                                                                                                                                                  |
 |:----------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| client_id                         | The unique identifier associated with the client making the eligibility request.                                                                                                                                        |
 | event                             | The patient event, service or procedure that is being submitted for review.                                                                                                                                        |
 | event.category                    | The category of the event being submitted for review. A full list of possible values can be found [below](#category).                                                                                                                                        |
 | event.certification_type          | The type of certification being requested. For new authorization requests, a certification value of "initial" should be used.                                                                |

--- a/source/includes/_claimstatus.md
+++ b/source/includes/_claimstatus.md
@@ -434,6 +434,7 @@ any matching claims:
 
 ```json
 {
+    "client_id": "<client_id>",
     "patient": {
         "claims": [
             {
@@ -495,7 +496,7 @@ name, and they are unable to find a match:
 
 ```json
 {  
-    "client_id":"fFFgqPeK5GETjZkC3JPB",
+    "client_id": "<client_id>",
     "payer":{  
         "name":"MOCKPAYER",
         "id":"MOCKPAYER"
@@ -531,6 +532,7 @@ has been paid:
 
 ```json
 {
+    "client_id": "<client_id>",
     "patient": {
         "claims": [
             {
@@ -700,6 +702,7 @@ has been paid:
 
 ```json
 {
+    "client_id": "<client_id>",
     "patient": {
         "claims": [
             {
@@ -916,6 +919,7 @@ been denied (not paid) and the charges are applied to the deductible:
 
 ```json
 {
+    "client_id": "<client_id>",
     "patient": {
         "claims": [
             {
@@ -1069,6 +1073,7 @@ The /claim/status response contains the following fields:
 
 | Field                                                 | Description                                                                                                                                                                                                                                                                                                                                        |
 |:------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| client_id                                             | The unique identifier associated with the client making the eligibility request.                                                                                                                                                                                                                                                                   |
 | trading_partner_id                                    | Unique id for the intended trading partner, as specified by the [Trading Partners](#trading-partners) endpoint.                                                                                                                                                                                                                                    |
 | payer                                                 | Information associated with the payer of the claim.                                                                                                                                                                                                                                                                                                |
 | payer.name                                            | The name of the payer                                                                                                                                                                                                                                                                                                                              |

--- a/source/includes/_eligibility.md
+++ b/source/includes/_eligibility.md
@@ -551,6 +551,7 @@ Map<String, Object> results = pd.eligibility(query);
 
 ```json
 {   
+    "client_id": "<client_id>",
     "coverage": {
         "active": false
         },
@@ -578,6 +579,7 @@ eligibility request:
 
 ```json
 {
+    "client_id": "<client_id>",
     "coverage": {
         "service_date": "2014-06-26"
     },
@@ -603,6 +605,7 @@ eligibility request:
 
 ```json
 {
+    "client_id": "<client_id>",
     "coverage": {
         "service_date": "2014-06-26"
     },
@@ -629,6 +632,7 @@ a CPT code:
 
 ```json
 {
+    "client_id": "<client_id>",
     "coverage": {
         "service_date": "2014-06-26"
     },
@@ -653,7 +657,9 @@ a CPT code:
 > Sample eligibility response for a successfully executed eligibility request:
 
 ```json
-{    "summary": {
+{   
+    "client_id": "<client_id>", 
+    "summary": {
          "deductible": {
              "individual": {
                   "in_network": {
@@ -1084,6 +1090,7 @@ a CPT code:
 
 ```json
 {
+    "client_id": "<client_id>",
     "coverage": {
         "active": true,
         "coinsurance": [
@@ -1558,6 +1565,7 @@ The /eligibility/ response contains the following fields:
 
 | Field                                               | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 |:----------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| client_id                                           | The unique identifier associated with the client making the eligibility request.                                                                                                                                                                                                                                                                                                                                                                                                      |
 | coverage.active                                     | A boolean value that is true when the member has active coverage. It is false when membership information could not be returned or when inactive coverage is indicated by the trading partner.                                                                                                                                                                                                                                                                                        |
 | coverage.coverage_details                           | Additional information relating to the coverage.                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | coverage.coverage_details.status                    | The status of the coverage.                                                                                                                                                                                                                                                                                                                                                                                                                                                           |

--- a/source/includes/_referrals.md
+++ b/source/includes/_referrals.md
@@ -207,6 +207,7 @@ Map<String, Object> results = pd.referrals(query);
 
 ```json
 {
+    "client_id": "<client_id>",
     "event": {
         "category": "specialty_care_review",
         "certification_type": "initial",
@@ -267,6 +268,7 @@ The /referrals/ endpoint uses the same object for both its parameters and respon
 
 | Parameter                                     | Description                                                                                                                                                                                                                           |
 |:----------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| client_id                                     | The unique identifier associated with the client making the eligibility request.                                                                                                                                                      |
 | event                                         | The patient event that is being submitted for approval.                                                                                                                                                                               |
 | event.category                                | The category of the event being submitted for review. For referrals to specialists, a category value of "specialty_care_review" should always be used.                                                                                |
 | event.delivery.units                          | The units of services being requested.                                                                                                                                                                                                |
@@ -288,8 +290,8 @@ The /referrals/ endpoint uses the same object for both its parameters and respon
 | event.review.certification_action             | Indicates the outcome of the review. For example, "certified_in_total" will be returned when the event is certified/authorized.  A full list of possible values can be found [below](#referral_certaction).                           |
 | event.review.certification_number             | The review certification/reference number.                                                                                                                                                                                            |
 | event.review.decision_reason                  | If the event is not authorized, the reason for that decision.  A full list of possible values can be found [below](#referral_decision).                                                                                               |
-| event.review.event_start_date                 | Effective date of referral.                                                                                                                                                                                                      |
-| event.review.event_end_date                   | End date for referral.                                                                                                                                                                                                           |
+| event.review.event_start_date                 | Effective date of referral.                                                                                                                                                                                                           |
+| event.review.event_end_date                   | End date for referral.                                                                                                                                                                                                                |
 | event.review.second_surgical_opinion_required | Boolean of whether or not a second surgical opinion is required.                                                                                                                                                                      |
 | event.type                                    | The type of service being requested. For example, a value of consultation would be used when referring to a specialist for an initial consultation.                                                                                   |
 | event.start_date                              | Optional: The start date of the given event. For a single date, provide only event.start_date. For a date range, provide event.start_date and event.end_date. Given in ISO8601 (YYYY-MM-DD).                                          |


### PR DESCRIPTION
Completion of [ENTERPRISE-393](https://pokitdok.atlassian.net/browse/ENTERPRISE-393) ticket which entailed the adding of `client_id` to descriptions and response JSON to endpoints that returned `client_id` in their `data` sections.