### PR TITLE
ENTERPRISE-433 : add 'name' to provider API request arguments

### DIFF
--- a/source/includes/_providers.md
+++ b/source/includes/_providers.md
@@ -383,7 +383,7 @@ The /providers/ endpoint accepts the following search parameters:
 | last_name         | {string} | The provider's last name                                                                                                                            |
 | gender            | {string} | The provider's gender                                                                                                                               |
 | organization_name | {string} | The business practice name                                                                                                                          |
-| name              | {string} | Queries against full_name, organization_name, and other_organization_name                                                                           |
+| name              | {string} | Queries against the provider's full name (first, middle, last) for individuals, organization and other organization names for organizations. For best results individual name properties and organization name should be omitted when passing this parameter.|
 | radius            | {string} | Search distance from geographic centerpoint, with unit (e.g. "1mi")                                                                                 |
 | specialty         | {string} | The provider's specialty name (e.g. "rheumatology").  Partial name-prefixes may be specified (e.g. "rheum")                                         |
 | state             | {string} | Name of U.S. state in which to search for providers (e.g. "CA" or "SC")                                                                             |

--- a/source/includes/_providers.md
+++ b/source/includes/_providers.md
@@ -382,8 +382,8 @@ The /providers/ endpoint accepts the following search parameters:
 | middle_name       | {string} | The provider's middle name                                                                                                                          |
 | last_name         | {string} | The provider's last name                                                                                                                            |
 | gender            | {string} | The provider's gender                                                                                                                               |
+| organization_name | {string} | The business practice name                                                                                                                          |
 | name              | {string} | Queries against full_name, organization_name, and other_organization_name                                                                           |
-| last_name         | {string} | The provider's last name                                                                                                                            |
 | radius            | {string} | Search distance from geographic centerpoint, with unit (e.g. "1mi")                                                                                 |
 | specialty         | {string} | The provider's specialty name (e.g. "rheumatology").  Partial name-prefixes may be specified (e.g. "rheum")                                         |
 | state             | {string} | Name of U.S. state in which to search for providers (e.g. "CA" or "SC")                                                                             |

--- a/source/includes/_providers.md
+++ b/source/includes/_providers.md
@@ -382,7 +382,8 @@ The /providers/ endpoint accepts the following search parameters:
 | middle_name       | {string} | The provider's middle name                                                                                                                          |
 | last_name         | {string} | The provider's last name                                                                                                                            |
 | gender            | {string} | The provider's gender                                                                                                                               |
-| organization_name | {string} | The business practice name                                                                                                                          |
+| name              | {string} | Queries against full_name, organization_name, and other_organization_name                                                                           |
+| last_name         | {string} | The provider's last name                                                                                                                            |
 | radius            | {string} | Search distance from geographic centerpoint, with unit (e.g. "1mi")                                                                                 |
 | specialty         | {string} | The provider's specialty name (e.g. "rheumatology").  Partial name-prefixes may be specified (e.g. "rheum")                                         |
 | state             | {string} | Name of U.S. state in which to search for providers (e.g. "CA" or "SC")                                                                             |


### PR DESCRIPTION
Completion of ticket [ENTERPRISE-433](https://pokitdok.atlassian.net/browse/ENTERPRISE-433) which entailed the addition of the `name` parameter to the providers request.