### PR TITLE
ENTERPRISE-333 : Removal of `payers` from documentation

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -33,7 +33,6 @@ includes:
   - identity
   - insuranceprices
   - mpc
-  - payers
   - pharmacy_formulary
   - pharmacy_network
   - pharmacy_plans


### PR DESCRIPTION
Completion of ticket [ENTERPRISE-333](https://pokitdok.atlassian.net/browse/ENTERPRISE-333) which entailed the removal of the `payers` endpoint from the public documentation. The payers endpoint is deprecated thus we do not want any new clients using it. 