### PR TITLE
X12-402: no hard break on the 1st cell; reduce sample box width

### DIFF
--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -54,7 +54,7 @@ $lang-select-pressed-text: #fff; // color of language tab text when mouse is pre
 // SIZES
 ////////////////////
 $nav-width: 230px; // width of the navbar
-$examples-width: 50%; // portion of the screen taken up by code examples
+$examples-width: 40%; // portion of the screen taken up by code examples
 $logo-margin: 20px; // margin between nav items and logo, ignored if search is active
 $main-padding: 28px; // padding to left and right of content & examples
 $nav-padding: 15px; // padding to left and right of navbar

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -449,6 +449,15 @@ html, body {
       word-wrap: break-word;
       min-width: 100px;
     }
+    /* first table cell is usually the api key so no hard break */
+    td:first-child {
+      /* For Firefox */
+      white-space: normal;
+      word-break: normal;
+
+      /* For Chrome and IE */
+      word-wrap: normal;
+    }
 
     tr:last-child {
       border-bottom: 1px solid #ccc;


### PR DESCRIPTION
this claims table is the worst scenario, other than that all other tables looks fine
<img width="721" alt="screen shot 2017-03-22 at 12 49 40 pm" src="https://cloud.githubusercontent.com/assets/1714406/24217715/050aa79e-0efe-11e7-972e-3f51294ec23d.png">
