### PR TITLE
SUCCESS-196 update insurance price API docs add details about standardized amount

### DIFF
--- a/source/includes/_insuranceprices.md
+++ b/source/includes/_insuranceprices.md
@@ -94,12 +94,8 @@ try client.insurancePrices(cptCode: "99203", zipCode: "94401")
       "standard_deviation": 8.986004924696134
     }
   ],
-  "location": {
-    "geo_zip_area": "944"
-  },
-  "procedure": {
-    "cpt_code": "99203"
-  }
+  "geo_zip_area": "944",
+  "cpt_code": "99203"
 }
 ```
 

--- a/source/includes/_insuranceprices.md
+++ b/source/includes/_insuranceprices.md
@@ -3,35 +3,35 @@
 > example fetching insurance price information
 
 ```shell
-curl -i -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/api/v4/prices/insurance?cpt_code=90658&zip_code=94401
+curl -i -H "Authorization: Bearer $ACCESS_TOKEN" https://platform.pokitdok.com/api/v4/prices/insurance?cpt_code=99203&zip_code=94401
 ```
 
 ```python
-client.insurance_prices(zip_code='94401', cpt_code='90658')
+client.insurance_prices(zip_code='94401', cpt_code='99203')
 ```
 
 ```csharp
 client.pricesInsurance(
 			new Dictionary<string, string> {
 				{ "zip_code", "94401" },
-				{ "cpt_code", "90658" }
+				{ "cpt_code", "99203" }
 			});
 ```
 
 ```ruby
-client.insurance_prices({zip_code: '94401', cpt_code: '90658'})
+client.insurance_prices({zip_code: '94401', cpt_code: '99203'})
 ```
 
 ```java
 HashMap<String, String>() query = new HashMap<String, String>();
 query.put("zip_code", "94401");
-query.put("cpt_code", "90658");
+query.put("cpt_code", "99203");
 
 client.insurancePrices(query);
 ```
 
 ```swift
-try client.insurancePrices(cptCode: "90658", zipCode: "94401")
+try client.insurancePrices(cptCode: "99203", zipCode: "94401")
 ```
 
 >Example Response:
@@ -40,26 +40,66 @@ try client.insurancePrices(cptCode: "90658", zipCode: "94401")
 {
   "amounts": [
     {
-      "high_price": 40.34,
-      "standard_deviation": 6.362073336381782,
-      "average_price": 20.896499999999996,
+      "average": 123.3645,
+      "high": 161.73,
+      "low": 108.08,
+      "median": 133.73,
       "payer_type": "insurance",
       "payment_type": "allowed",
-      "low_price": 14.8,
-      "median_price": 20.33
+      "standard_deviation": 15.85575484603303
     },
     {
-      "high_price": 54.62,
-      "standard_deviation": 10.572772826345037,
-      "average_price": 32.0905,
+      "average": 208.80499999999998,
+      "high": 280.73,
+      "low": 182.45,
+      "median": 208.21,
       "payer_type": "insurance",
       "payment_type": "submitted",
-      "low_price": 22.42,
-      "median_price": 31.2
+      "standard_deviation": 34.80339356657624
+    },
+    {
+      "average": 74.22024823703075,
+      "high": 83.913333333,
+      "low": 17.922,
+      "median": 75.92828482041077,
+      "payer_type": "medicare",
+      "payment_type": "standardized",
+      "standard_deviation": 7.521841261411875
+    },
+    {
+      "average": 87.68441466859153,
+      "high": 97.162777778,
+      "low": 14.5365,
+      "median": 90.50126353946429,
+      "payer_type": "medicare",
+      "payment_type": "paid",
+      "standard_deviation": 9.672560546364663
+    },
+    {
+      "average": 238.48777715084063,
+      "high": 525,
+      "low": 125,
+      "median": 234,
+      "payer_type": "medicare",
+      "payment_type": "submitted",
+      "standard_deviation": 59.51082623548598
+    },
+    {
+      "average": 126.08792947814867,
+      "high": 128.68,
+      "low": 73.27,
+      "median": 128.68,
+      "payer_type": "medicare",
+      "payment_type": "allowed",
+      "standard_deviation": 8.986004924696134
     }
   ],
-  "cpt_code": "90658",
-  "geo_zip_area": "944"
+  "location": {
+    "geo_zip_area": "944"
+  },
+  "procedure": {
+    "cpt_code": "99203"
+  }
 }
 ```
 

--- a/source/includes/_insuranceprices.md
+++ b/source/includes/_insuranceprices.md
@@ -40,22 +40,22 @@ try client.insurancePrices(cptCode: "90658", zipCode: "94401")
 {
   "amounts": [
     {
-      "high_price": 24.38,
-      "standard_deviation": 3.409736666884995,
-      "average_price": 18.491500000000002,
+      "high_price": 40.34,
+      "standard_deviation": 6.362073336381782,
+      "average_price": 20.896499999999996,
       "payer_type": "insurance",
       "payment_type": "allowed",
-      "low_price": 13.57,
-      "median_price": 19.27
+      "low_price": 14.8,
+      "median_price": 20.33
     },
     {
-      "high_price": 51.71,
-      "standard_deviation": 8.675179825225527,
-      "average_price": 32.05,
+      "high_price": 54.62,
+      "standard_deviation": 10.572772826345037,
+      "average_price": 32.0905,
       "payer_type": "insurance",
       "payment_type": "submitted",
-      "low_price": 24.32,
-      "median_price": 31.02
+      "low_price": 22.42,
+      "median_price": 31.2
     }
   ],
   "cpt_code": "90658",
@@ -94,11 +94,10 @@ The /prices/insurance response contains the following fields:
 |:----------------------------|:----------|:----------------------------------------------------------------|:---------|
 | cpt_code      	    	  | {string}  | The CPT code of the procedure                                   | Required |
 | geo_zip_area  			  | {string}  | The three character zip code tabulation area code               | Required |
-| description    			  | {string}  | Description of the returned insurance prices.               	| Required |
 | amounts.high_price    	  | {decimal} | The maximum price for the procedure                             | Required |
 | amounts.standard_deviation  | {decimal} | Standard deviation of the insurance price amounts.              | Required |
 | amounts.average_price 	  | {decimal} | The weighted average price based on the number of procedures    | Required |
 | amounts.low_price     	  | {decimal} | The lowest price for the procedure                              | Required |
 | amounts.median_price  	  | {decimal} | The median price for the procedure                              | Required |
 | amounts.payer_type    	  | {string}  | The insurance payer type: insurance or medicare                 | Required |
-| amounts.payment_type  	  | {string}  | Possible values are "allowed", "submitted", or "paid". The allowed amount is the dollar amount typically considered payment-in-full by a payer and an associated network of healthcare providers. For Medicare, the allowed amount is the average of the Medicare allowed amount for the service; this figure is the sum of the amount Medicare pays, the deductible and coinsurance amounts, and any amounts that a third party is responsible for paying. The submitted amount is the dollar amount the provider submitted to the payer in the insurance claim. The paid amount is the dollar amount that was reimbursed to the provider. | Required |
+| amounts.payment_type  	  | {string}  | Possible values are "allowed", "submitted", "paid", or "standardized". The allowed amount when payer_type:insurance is the dollar amount typically considered payment-in-full by a payer and an associated network of healthcare providers. For Medicare (when payer_type:medicare) the allowed amount is the average of the Medicare allowed amount for the service; this figure is the sum of the amount Medicare pays, the deductible and coinsurance amounts, and any amounts that a third party is responsible for paying. The submitted amount is the dollar amount the provider submitted to the payer in the insurance claim. The paid amount is the dollar amount that was reimbursed to the provider.  The standardized amount removes geographic differences in payment rates for individual services. | Required |


### PR DESCRIPTION
update insurance price API docs add details about standardized amount

1. added description for `standardized` amount

2. removed `description` in response--this has been deprecated for a long time and not returned in the response.

3. also updated example document to match test mode response (CPT 99203)