### PR TITLE
EV-39: update the csharp example for mpc

### DIFF
--- a/source/includes/_mpc.md
+++ b/source/includes/_mpc.md
@@ -49,7 +49,7 @@ client.mpc(name='office')
 ```
 
 ```csharp
-client.medicalProcedureCode(
+client.mpc(
     new Dictionary<string, string> {
         {"name", "Established patient office or other outpatient visit, typically 15 minutes"}
     });


### PR DESCRIPTION
Previously, the csharp client's convenience function for `mpc` was `medicalProcedureCode`.  

This moves the example in the docs to use `mpc`, as expected per the recent update to the client. 

https://github.com/pokitdok/pokitdok-csharp/blob/master/PlatformClient.cs#L562