### PR TITLE
SUCCESS-1883 Add NPI registration documentation.

### DIFF
--- a/source/includes/_appregistrations.md
+++ b/source/includes/_appregistrations.md
@@ -103,9 +103,10 @@ The POST `/appregistrations/` and PUT `/appregistrations/` endpoints accept the 
 |:---|:---|:---|:--- |
 | address_lines | {list} | List of strings representing the street address. (e.g. ["123 Main ST.", "Suite 4"]) | Required |
 | claims_roles | {list} | List of roles (e.g. 'billing' or 'rendering').| Required |
-| first_name | {string} | Patient's first name. | Required |
-| last_name | {string} | Patient's last name. | Required |
-| npi | {string} | The provider's NPI. | Required |
+| first_name | {string} | Provider's first name. This field should be omitted when sending organization_name| Situational |
+| last_name | {string} | Provider's last name. This field should be omitted when sending organization_name| Situational |
+| npi | {string} | The provider's NPI. | Situational |
+| organization_name | {string} | The provider's organization name. This field should be omitted when sending first_name and last_name | Situational |
 | tax_id | {list} | List of  federal tax ids for the provider. For individual providers, this may be the tax id of the medical practice or organization where a provider works. | Required |
 | trading_partner_id| {string} | Unique ID for the intended trading partner, as specified by the [Trading Partners](#trading-partners) endpoint.| Required |
 | transaction_set_name | {string} | Transaction this app registration is to be used for (e.g. 'eligibility', 'claims', or 'claim_status'). | Required |
@@ -125,9 +126,10 @@ The `/appregistrations/` response contains the following fields:
 | app_name | {string} | The name of the app associated to the app registration. |
 | claims_roles | {list} | List of roles (e.g. 'billing' or 'rendering').| Required |
 | client_id | {string} | The client ID of the app associated to the app registration. |
-| first_name | {string} | Patient's first name. |
-| last_name | {string} | Patient's last name. |
+| first_name | {string} | Provider's first name. |
+| last_name | {string} | Provider's last name. |
 | npi | {string} | The provider's NPI. |
+| organization_name | {string} | The provider's organization name. |
 | tax_id | {list} | List of  federal tax ids for the provider. For individual providers, this may be the tax id of the medical practice or organization where a provider works. |
 | trading_partner_id| {string} | Unique ID for the intended trading partner, as specified by the [Trading Partners](#trading-partners) endpoint.|
 | transaction_set_name | {string} | Transaction this app registration is to be used for (e.g. 'eligibility', 'claims', or claim_status). |

--- a/source/includes/_appregistrations.md
+++ b/source/includes/_appregistrations.md
@@ -13,7 +13,7 @@ curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/j
         "state": "CA",
         "tax_id": ["123456789"],
         "trading_partner_id": "MOCKPAYER",
-        "trading_partner_set_name": "eligibility",
+        "transaction_set_name": "eligibility",
         "zipcode": "99401"
     }' https://platform.pokitdok.com/api/v4/appregistrations
 ```
@@ -30,7 +30,7 @@ params = {
     'state': 'CA',
     'tax_id': ['123456789'],
     'trading_partner_id': 'MOCKPAYER',
-    'trading_partner_set_name': 'eligibility',
+    'transaction_set_name': 'eligibility',
     'zipcode': '99401'
 }
 response = pd.post('/appregistrations/', data=params)
@@ -55,7 +55,7 @@ Dictionary<string, object> data = new Dictionary<string, object> {
     {"state": "CA"},
     {"tax_id": tax_id},
     {"trading_partner_id": "MOCKPAYER"},
-    {"trading_partner_set_name": "eligibility"},
+    {"transaction_set_name": "eligibility"},
     {"zipcode": "99401"}
     };
 client.request(endpoint, method, data);
@@ -72,7 +72,7 @@ client.request('/appregistrations/', method='post', params={
     state: 'CA',
     tax_id: ['123456789'],
     trading_partner_id: 'MOCKPAYER',
-    trading_partner_set_name: 'eligibility',
+    transaction_set_name: 'eligibility',
     zipcode: '99401'
 })
 ```
@@ -88,7 +88,7 @@ let data = [
     "state": "CA",
     "tax_id": ["123456789"],
     "trading_partner_id": "MOCKPAYER",
-    "trading_partner_set_name": "eligibility",
+    "transaction_set_name": "eligibility",
     "zipcode": "99401"
 ] as [String:any]
 try client.request(path: "/appregistrations", method: "POST", params: data)
@@ -146,18 +146,18 @@ The POST `/appregistrations/` and PUT `/appregistrations/` endpoints accept the 
 
 | Parameter | Type | Description | Presence |
 |:---|:---|:---|:--- |
-| address_lines | {list} | List of strings representing the street address. (e.g. ["123 Main ST.", "Suite 4"]) | Required |
+| address_lines | {list} | List of strings representing the street address (e.g. ["123 Main ST.", "Suite 4"]). | Required |
 | claims_roles | {list} | List of roles (e.g. 'billing' or 'rendering').| Required |
 | city | {string} | The city component of an address (e.g. 'SAN MATEO'). | Required |
-| first_name | {string} | Provider's first name. This field should be omitted when sending organization_name| Situational |
-| last_name | {string} | Provider's last name. This field should be omitted when sending organization_name| Situational |
+| first_name | {string} | Provider's first name. This field should be omitted when sending organization_name. | Situational |
+| last_name | {string} | Provider's last name. This field should be omitted when sending organization_name. | Situational |
 | npi | {string} | The provider's NPI. | Required |
-| organization_name | {string} | The provider's organization name. This field should be omitted when sending first_name and last_name | Situational |
+| organization_name | {string} | The provider's organization name. This field should be omitted when sending first_name and last_name. | Situational |
 | state | {string} | The state component of an address (e.g. 'CA'). | Required |
 | tax_id | {list} | List of  federal tax ids for the provider. For individual providers, this may be the tax id of the medical practice or organization where a provider works. | Required |
 | trading_partner_id| {string} | Unique ID for the intended trading partner, as specified by the [Trading Partners](#trading-partners) endpoint.| Required |
 | transaction_set_name | {string} | Transaction this app registration is to be used for (e.g. 'eligibility', 'claims', or 'claim_status'). | Required |
-| zipcode | {string} | The zip/postal code. (e.g. "94401") | Required |
+| zipcode | {string} | The zip/postal code (e.g. "94401"). | Required |
 
 <!--- end of table -->
 
@@ -169,7 +169,7 @@ The `/appregistrations/` response contains the following fields:
 | Field | Type | Description |
 |:---|:---|:---|
 | _uuid | {string} | The unique ID for this app registration.|
-| address_lines | {list} | List of strings representing the street address. (e.g. ["123 Main ST.", "Suite 4"]) | Required |
+| address_lines | {list} | List of strings representing the street address. (e.g. ["123 Main ST.", "Suite 4"]). | Required |
 | app_name | {string} | The name of the app associated to the app registration. |
 | claims_roles | {list} | List of roles (e.g. 'billing' or 'rendering').| Required |
 | city | {string} | The city component of an address (e.g. 'SAN MATEO'). | Required |
@@ -182,4 +182,4 @@ The `/appregistrations/` response contains the following fields:
 | tax_id | {list} | List of  federal tax ids for the provider. For individual providers, this may be the tax id of the medical practice or organization where a provider works. |
 | trading_partner_id| {string} | Unique ID for the intended trading partner, as specified by the [Trading Partners](#trading-partners) endpoint.|
 | transaction_set_name | {string} | Transaction this app registration is to be used for (e.g. 'eligibility', 'claims', or claim_status). |
-| zipcode | {string} | The zip/postal code. (e.g. "94401") | Required |
+| zipcode | {string} | The zip/postal code (e.g. "94401"). | Required |

--- a/source/includes/_appregistrations.md
+++ b/source/includes/_appregistrations.md
@@ -7,7 +7,7 @@ curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/j
         "trading_partner_id": "MOCKPAYER",
         "trading_partner_set_name": "eligibility,
         "tax_id": ["123456789"],
-        "npi": "12345678903"
+        "npi": "1234567893"
     }' https://platform.pokitdok.com/api/v4/appregistrations
 ```
 
@@ -23,6 +23,38 @@ params = {
 response = pd.post('/appregistrations/', data=params)
 ```
 
+```csharp
+string endpoint = "/appregistrations/";
+string method - "POST";
+List<string> tax_id = new List<string>
+tax_id.Add("123456789")
+Dictionary<string, object> data = new Dictionary<string, object> {
+    {"trading_partner_id", "MOCKPAYER"},
+    {"transaction_set_name", "eligibility" },
+    {"tax_id", tax_id},
+    {"npi", "1234567893" }
+    };
+client.request(endpoint, method, data);
+```
+
+```ruby
+client.request('/appregistrations/', method='post', params={
+    trading_partner_id: "MOCKPAYER",
+    transaction_set_name: "eligibility",
+    tax_id: ["123456789"],
+    npi: "1234567893"
+})
+```
+
+```swift
+let data = [
+    "trading_partner_id": "MOCKPAYER",
+    "transaction_set_name": "eligibility",
+    "tax_id": ["123456789"],
+    "npi": "1234567893"
+] as [String:any]
+try client.request(path: "/appregistrations", method: "POST", params: data)
+```
 
 > Example response:
 

--- a/source/includes/_appregistrations.md
+++ b/source/includes/_appregistrations.md
@@ -4,54 +4,92 @@
 ```shell
 curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json"
     -XPOST -d '{
-        "trading_partner_id": "MOCKPAYER",
-        "trading_partner_set_name": "eligibility,
-        "tax_id": ["123456789"],
+        "address_lines": ["123 MAIN ST"],
+        "city": "San Mateo",
+        "claims_roles": ["billing"],
+        "first_name": "Jane",
+        "last_name": "Doe",
         "npi": "1234567893"
+        "state": "CA",
+        "tax_id": ["123456789"],
+        "trading_partner_id": "MOCKPAYER",
+        "trading_partner_set_name": "eligibility",
+        "zipcode": "99401"
     }' https://platform.pokitdok.com/api/v4/appregistrations
 ```
 
 
 ```python
 params = {
-    'trading_partner_id': 'MOCKPAYER',
-    'transaction_set_name': 'eligibility',
-    'tax_id': ['123456789'],
+    'address_lines': ['123 MAIN ST'],
+    'city': 'San Mateo',
+    'claims_roles': ['billing'],
+    'first_name': 'Jane',
+    'last_name': 'Doe',
     'npi': '1234567893'
+    'state': 'CA',
+    'tax_id': ['123456789'],
+    'trading_partner_id': 'MOCKPAYER',
+    'trading_partner_set_name': 'eligibility',
+    'zipcode': '99401'
 }
-
 response = pd.post('/appregistrations/', data=params)
 ```
 
 ```csharp
 string endpoint = "/appregistrations/";
 string method - "POST";
-List<string> tax_id = new List<string>
-tax_id.Add("123456789")
+List<string> tax_id = new List<string>;
+tax_id.Add("123456789");
+List<string> address_lines = new List<string>;
+address_lines.Add("123 MAIN ST");
+List<string> claims_roles = new List<string>;
+claims_roles.Add("billing");
 Dictionary<string, object> data = new Dictionary<string, object> {
-    {"trading_partner_id", "MOCKPAYER"},
-    {"transaction_set_name", "eligibility" },
-    {"tax_id", tax_id},
-    {"npi", "1234567893" }
+    {"address_lines": address_lines},
+    {"city": "San Mateo"},
+    {"claims_roles": claims_roles},
+    {"first_name": "Jane"},
+    {"last_name": "Doe"},
+    {"npi": "1234567893"}
+    {"state": "CA"},
+    {"tax_id": tax_id},
+    {"trading_partner_id": "MOCKPAYER"},
+    {"trading_partner_set_name": "eligibility"},
+    {"zipcode": "99401"}
     };
 client.request(endpoint, method, data);
 ```
 
 ```ruby
 client.request('/appregistrations/', method='post', params={
-    trading_partner_id: "MOCKPAYER",
-    transaction_set_name: "eligibility",
-    tax_id: ["123456789"],
-    npi: "1234567893"
+    address_lines: ['123 MAIN ST'],
+    city: 'San Mateo',
+    claims_roles: ['billing'],
+    first_name: 'Jane',
+    last_name: 'Doe',
+    npi: '1234567893'
+    state: 'CA',
+    tax_id: ['123456789'],
+    trading_partner_id: 'MOCKPAYER',
+    trading_partner_set_name: 'eligibility',
+    zipcode: '99401'
 })
 ```
 
 ```swift
 let data = [
-    "trading_partner_id": "MOCKPAYER",
-    "transaction_set_name": "eligibility",
-    "tax_id": ["123456789"],
+    "address_lines": ["123 MAIN ST"],
+    "city": "San Mateo",
+    "claims_roles": ["billing"],
+    "first_name": "Jane",
+    "last_name": "Doe",
     "npi": "1234567893"
+    "state": "CA",
+    "tax_id": ["123456789"],
+    "trading_partner_id": "MOCKPAYER",
+    "trading_partner_set_name": "eligibility",
+    "zipcode": "99401"
 ] as [String:any]
 try client.request(path: "/appregistrations", method: "POST", params: data)
 ```
@@ -62,12 +100,19 @@ try client.request(path: "/appregistrations", method: "POST", params: data)
 {
     "data": {
         "_uuid": "2f201868-47f4-11e8-a91a-0242ac12000a",
+        "address_lines": ["123 Main ST"],
         "app_name": "<app_name>",
+        "city": "San Mateo",
+        "claims_roles": ["billing"],
         "client_id": "<client_id>",
+        "first_name": "Jane",
+        "last_name": "Doe",
         "npi": "1234567893",
+        "state": "CA",
         "tax_id": ["123456789"],
         "trading_partner_id": "MOCKPAYER",
-        "transaction_set_name": "eligibility"
+        "transaction_set_name": "eligibility",
+        "zipcode": "94401"
     },
     "meta": {
         "...": "..."
@@ -103,10 +148,12 @@ The POST `/appregistrations/` and PUT `/appregistrations/` endpoints accept the 
 |:---|:---|:---|:--- |
 | address_lines | {list} | List of strings representing the street address. (e.g. ["123 Main ST.", "Suite 4"]) | Required |
 | claims_roles | {list} | List of roles (e.g. 'billing' or 'rendering').| Required |
+| city | {string} | The city component of an address (e.g. 'SAN MATEO'). | Required |
 | first_name | {string} | Provider's first name. This field should be omitted when sending organization_name| Situational |
 | last_name | {string} | Provider's last name. This field should be omitted when sending organization_name| Situational |
 | npi | {string} | The provider's NPI. | Situational |
 | organization_name | {string} | The provider's organization name. This field should be omitted when sending first_name and last_name | Situational |
+| state | {string} | The state component of an address (e.g. 'CA'). | Required |
 | tax_id | {list} | List of  federal tax ids for the provider. For individual providers, this may be the tax id of the medical practice or organization where a provider works. | Required |
 | trading_partner_id| {string} | Unique ID for the intended trading partner, as specified by the [Trading Partners](#trading-partners) endpoint.| Required |
 | transaction_set_name | {string} | Transaction this app registration is to be used for (e.g. 'eligibility', 'claims', or 'claim_status'). | Required |
@@ -125,11 +172,13 @@ The `/appregistrations/` response contains the following fields:
 | address_lines | {list} | List of strings representing the street address. (e.g. ["123 Main ST.", "Suite 4"]) | Required |
 | app_name | {string} | The name of the app associated to the app registration. |
 | claims_roles | {list} | List of roles (e.g. 'billing' or 'rendering').| Required |
+| city | {string} | The city component of an address (e.g. 'SAN MATEO'). | Required |
 | client_id | {string} | The client ID of the app associated to the app registration. |
 | first_name | {string} | Provider's first name. |
 | last_name | {string} | Provider's last name. |
 | npi | {string} | The provider's NPI. |
 | organization_name | {string} | The provider's organization name. |
+| state | {string} | The state component of an address (e.g. 'CA'). | Required |
 | tax_id | {list} | List of  federal tax ids for the provider. For individual providers, this may be the tax id of the medical practice or organization where a provider works. |
 | trading_partner_id| {string} | Unique ID for the intended trading partner, as specified by the [Trading Partners](#trading-partners) endpoint.|
 | transaction_set_name | {string} | Transaction this app registration is to be used for (e.g. 'eligibility', 'claims', or claim_status). |

--- a/source/includes/_appregistrations.md
+++ b/source/includes/_appregistrations.md
@@ -89,7 +89,7 @@ Available Endpoints:
 | /appregistrations | POST | Create an app registration. |
 | /appregistrations/{uuid} | PUT | Edit the app registration with the given UUID. |
 | /appregistrations/{uuid} | DELETE | Delete the app registration with the given UUID. |
-| /appregistrations/{uuid}/undelete | POST |Undelete the app registration with the given UUID |
+| /appregistrations/{uuid}/undelete | POST |Undelete the app registration with the given UUID. |
 
 <!--- end of table -->
 
@@ -104,7 +104,7 @@ The POST `/appregistrations/` and PUT `/appregistrations/` endpoints accept the 
 | address_lines | {list} | List of strings representing the street address. (e.g. ["123 Main ST.", "Suite 4"]) | Required |
 | claims_roles | {list} | List of roles (e.g. 'billing' or 'rendering').| Required |
 | first_name | {string} | Patient's first name. | Required |
-| last_name| { string} | Patient's last name. | Required |
+| last_name | {string} | Patient's last name. | Required |
 | npi | {string} | The provider's NPI. | Required |
 | tax_id | {list} | List of  federal tax ids for the provider. For individual providers, this may be the tax id of the medical practice or organization where a provider works. | Required |
 | trading_partner_id| {string} | Unique ID for the intended trading partner, as specified by the [Trading Partners](#trading-partners) endpoint.| Required |
@@ -126,7 +126,7 @@ The `/appregistrations/` response contains the following fields:
 | claims_roles | {list} | List of roles (e.g. 'billing' or 'rendering').| Required |
 | client_id | {string} | The client ID of the app associated to the app registration. |
 | first_name | {string} | Patient's first name. |
-| last_name| { string} | Patient's last name. |
+| last_name | {string} | Patient's last name. |
 | npi | {string} | The provider's NPI. |
 | tax_id | {list} | List of  federal tax ids for the provider. For individual providers, this may be the tax id of the medical practice or organization where a provider works. |
 | trading_partner_id| {string} | Unique ID for the intended trading partner, as specified by the [Trading Partners](#trading-partners) endpoint.|

--- a/source/includes/_appregistrations.md
+++ b/source/includes/_appregistrations.md
@@ -151,7 +151,7 @@ The POST `/appregistrations/` and PUT `/appregistrations/` endpoints accept the 
 | city | {string} | The city component of an address (e.g. 'SAN MATEO'). | Required |
 | first_name | {string} | Provider's first name. This field should be omitted when sending organization_name| Situational |
 | last_name | {string} | Provider's last name. This field should be omitted when sending organization_name| Situational |
-| npi | {string} | The provider's NPI. | Situational |
+| npi | {string} | The provider's NPI. | Required |
 | organization_name | {string} | The provider's organization name. This field should be omitted when sending first_name and last_name | Situational |
 | state | {string} | The state component of an address (e.g. 'CA'). | Required |
 | tax_id | {list} | List of  federal tax ids for the provider. For individual providers, this may be the tax id of the medical practice or organization where a provider works. | Required |

--- a/source/includes/_appregistrations.md
+++ b/source/includes/_appregistrations.md
@@ -1,6 +1,17 @@
 ## App Registrations
 > Example POST request:
 
+```shell
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" -H "Content-Type: application/json"
+    -XPOST -d '{
+        "trading_partner_id": "MOCKPAYER",
+        "trading_partner_set_name": "eligibility,
+        "tax_id": ["123456789"],
+        "npi": "12345678903"
+    }' https://platform.pokitdok.com/api/v4/appregistrations
+```
+
+
 ```python
 params = {
     'trading_partner_id': 'MOCKPAYER',

--- a/source/includes/_appregistrations.md
+++ b/source/includes/_appregistrations.md
@@ -1,0 +1,82 @@
+## App Registrations
+> Example POST request:
+
+```python
+params = {
+    'trading_partner_id': 'MOCKPAYER',
+    'transaction_set_name': 'eligibility',
+    'tax_id': ['123456789'],
+    'npi': '1234567893'
+}
+
+response = pd.post('/appregistrations/', data=params)
+```
+
+
+> Example response:
+
+```json
+{
+    "data": {
+        "_uuid": "2f201868-47f4-11e8-a91a-0242ac12000a",
+        "app_name": "<app_name>",
+        "client_id": "<client_id>",
+        "npi": "1234567893",
+        "tax_id": ["123456789"],
+        "trading_partner_id": "MOCKPAYER",
+        "transaction_set_name": "eligibility"
+    },
+    "meta": {
+        "...": "..."
+    }
+}
+```
+
+The App Regisrations endpoint allows users to to manage their app registrations. These endpoints can be used to create, edit, and delete app registrations.
+
+### Endpoint Description
+
+Available Endpoints:
+
+<!--- beginning of table -->
+| Endpoint | HTTP Method | Description |
+|:---|:---|:---|
+| /appregistrations | GET | List current app registrations. |
+| /appregistrations/{uuid} | GET | Retrieve the app registration with the given UUID. |
+| /appregistrations | POST | Create an app registration. |
+| /appregistrations/csv | POST | Create app registrations based on the CSV file. |
+| /appregistrations/{uuid} | PUT | Edit the app registration with the given UUID. |
+| /appregistrations/{uuid} | DELETE | Delete the app registration with the given UUID. |
+| /appregistrations/{uuid}/undelete | POST |Undelete the app registration with the given UUID |
+
+<!--- end of table -->
+
+### Parameters
+
+The POST `/appregistrations/` and PUT `/appregistrations/` endpoints accept the following parameters:
+
+<!--- beginning of table -->
+
+| Parameter | Type | Description | Presence |
+|:---|:---|:---|:--- |
+|trading_partner_id| {string} | Unique ID for the intended trading partner, as specified by the [Trading Partners](#trading-partners) endpoint.| Required |
+| transaction_set_name | {string} | Transaction this app registration is to be used for (e.g. 'eligibility' or 'claims'). | Required |
+| tax_id | {list} | List of  federal tax ids for the provider. For individual providers, this may be the tax id of the medical practice or organization where a provider works. | Required |
+| npi | {string} | The provider's NPI. | Required |
+
+<!--- end of table -->
+
+### Response
+
+The `/appregistrations/` response contains the following fields:
+
+<!--- beginning of table -->
+| Field | Type | Description |
+|:---|:---|:---|
+| _uuid | {string} | The unique ID for this app registration.|
+| app_name | {string} | The name of the app associated to the app registration. |
+| client_id | {string} | The client ID of the app associated to the app registration. |
+|trading_partner_id| {string} | Unique ID for the intended trading partner, as specified by the [Trading Partners](#trading-partners) endpoint.|
+| transaction_set_name | {string} | Transaction this app registration is to be used for (e.g. 'eligibility' or 'claims'). |
+| tax_id | {list} | List of  federal tax ids for the provider. For individual providers, this may be the tax id of the medical practice or organization where a provider works. |
+| npi | {string} | The provider's NPI. |

--- a/source/includes/_appregistrations.md
+++ b/source/includes/_appregistrations.md
@@ -75,7 +75,7 @@ try client.request(path: "/appregistrations", method: "POST", params: data)
 }
 ```
 
-The App Regisrations endpoint allows users to to manage their app registrations. These endpoints can be used to create, edit, and delete app registrations.
+The App Registrations endpoint allows user to manage the NPI registrations associated with their account. These endpoints can be used to create, edit, and delete registrations.
 
 ### Endpoint Description
 
@@ -87,7 +87,6 @@ Available Endpoints:
 | /appregistrations | GET | List current app registrations. |
 | /appregistrations/{uuid} | GET | Retrieve the app registration with the given UUID. |
 | /appregistrations | POST | Create an app registration. |
-| /appregistrations/csv | POST | Create app registrations based on the CSV file. |
 | /appregistrations/{uuid} | PUT | Edit the app registration with the given UUID. |
 | /appregistrations/{uuid} | DELETE | Delete the app registration with the given UUID. |
 | /appregistrations/{uuid}/undelete | POST |Undelete the app registration with the given UUID |
@@ -102,10 +101,15 @@ The POST `/appregistrations/` and PUT `/appregistrations/` endpoints accept the 
 
 | Parameter | Type | Description | Presence |
 |:---|:---|:---|:--- |
-|trading_partner_id| {string} | Unique ID for the intended trading partner, as specified by the [Trading Partners](#trading-partners) endpoint.| Required |
-| transaction_set_name | {string} | Transaction this app registration is to be used for (e.g. 'eligibility' or 'claims'). | Required |
-| tax_id | {list} | List of  federal tax ids for the provider. For individual providers, this may be the tax id of the medical practice or organization where a provider works. | Required |
+| address_lines | {list} | List of strings representing the street address. (e.g. ["123 Main ST.", "Suite 4"]) | Required |
+| claims_roles | {list} | List of roles (e.g. 'billing' or 'rendering').| Required |
+| first_name | {string} | Patient's first name. | Required |
+| last_name| { string} | Patient's last name. | Required |
 | npi | {string} | The provider's NPI. | Required |
+| tax_id | {list} | List of  federal tax ids for the provider. For individual providers, this may be the tax id of the medical practice or organization where a provider works. | Required |
+| trading_partner_id| {string} | Unique ID for the intended trading partner, as specified by the [Trading Partners](#trading-partners) endpoint.| Required |
+| transaction_set_name | {string} | Transaction this app registration is to be used for (e.g. 'eligibility', 'claims', or 'claim_status'). | Required |
+| zipcode | {string} | The zip/postal code. (e.g. "94401") | Required |
 
 <!--- end of table -->
 
@@ -117,9 +121,14 @@ The `/appregistrations/` response contains the following fields:
 | Field | Type | Description |
 |:---|:---|:---|
 | _uuid | {string} | The unique ID for this app registration.|
+| address_lines | {list} | List of strings representing the street address. (e.g. ["123 Main ST.", "Suite 4"]) | Required |
 | app_name | {string} | The name of the app associated to the app registration. |
+| claims_roles | {list} | List of roles (e.g. 'billing' or 'rendering').| Required |
 | client_id | {string} | The client ID of the app associated to the app registration. |
-|trading_partner_id| {string} | Unique ID for the intended trading partner, as specified by the [Trading Partners](#trading-partners) endpoint.|
-| transaction_set_name | {string} | Transaction this app registration is to be used for (e.g. 'eligibility' or 'claims'). |
-| tax_id | {list} | List of  federal tax ids for the provider. For individual providers, this may be the tax id of the medical practice or organization where a provider works. |
+| first_name | {string} | Patient's first name. |
+| last_name| { string} | Patient's last name. |
 | npi | {string} | The provider's NPI. |
+| tax_id | {list} | List of  federal tax ids for the provider. For individual providers, this may be the tax id of the medical practice or organization where a provider works. |
+| trading_partner_id| {string} | Unique ID for the intended trading partner, as specified by the [Trading Partners](#trading-partners) endpoint.|
+| transaction_set_name | {string} | Transaction this app registration is to be used for (e.g. 'eligibility', 'claims', or claim_status). |
+| zipcode | {string} | The zip/postal code. (e.g. "94401") | Required |

--- a/source/index.md
+++ b/source/index.md
@@ -27,6 +27,7 @@ includes:
   - clientlibraries
   - endpoints
   - activities
+  - appregistrations
   - cashprices
   - claims
   - claimsconvert


### PR DESCRIPTION
We're adding documentation to new endpoints we've implemented to let users manage their own NPI registrations without going through the user dashboard.