### PR TITLE
SUCCESS-3774: document errors that may be generated by some partners and return X12 999 or TA1 data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM ruby:2.1.5
 
-RUN apt-get update
 WORKDIR /app
 ADD Gemfile* /app/
 RUN bundle install

--- a/source/includes/_claimstatus.md
+++ b/source/includes/_claimstatus.md
@@ -1162,6 +1162,9 @@ The speed at which a claim is adjudicated is dependent on the trading partner. O
 To understand how the [Claims](#claims) and [Claims Status](#claims_status) Endpoints work together,
 see the [claims API workflow](https://pokitdok.com/developers/api/#api-claims-status).
 
+See the [errors](#errors) section of the documentation for details on Trading Partner specific request processing errors
+that may occur with this API for some request/partner combinations.
+
 ### Endpoint Description
 
 

--- a/source/includes/_common.md
+++ b/source/includes/_common.md
@@ -249,6 +249,95 @@ See cURL example.
 See cURL example.
 ```
 
+> Trading Partner specific request processing errors
+
+```shell
+curl -i -H "Content-Type: application/json" -H "Authorization: Bearer $ACCESS_TOKEN" -d "{...}"
+https://platform.pokitdok.com/api/v4/eligibility/
+{
+    "meta": {
+        "activity_id": "53d9506356c02c67c1010001",
+        "application_mode": "production",
+        "credits_billed": 0,
+        "credits_remaining": 995,
+        "processing_time": 300,
+        "rate_limit_amount": 2,
+        "rate_limit_cap": 1000,
+        "rate_limit_reset": 1394138991
+    },
+    "data": {
+        "errors": {
+            "parsing": {
+                "application_receiver_code": "000000001",
+                "application_sender_code": "000000002",
+                "functional_group_acknowledge": "Rejected",
+                "functional_group_acknowledge_code": "R",
+                "functional_identifier_code": "HS",
+                "group_control_number": "1",
+                "number_of_accepted_transaction_sets": 0,
+                "number_of_received_transaction_sets": 1,
+                "number_of_transaction_sets_included": 1,
+                "segment_errors": [
+                    {
+                        "loop_id_code": "2100",
+                        "notes": [
+                            {
+                                "data_element_syntax_error": "Required Data Element Missing",
+                                "data_element_syntax_error_code": "1",
+                                "element_reference_number": 1035,
+                                "position_in_segment": "3"
+                            },
+                            {
+                                "data_element_syntax_error": "Implementation Dependent Data Element Missing",
+                                "data_element_syntax_error_code": "I9",
+                                "element_reference_number": 1036,
+                                "position_in_segment": "4"
+                            }
+                        ],
+                        "position_in_transaction_set": 6,
+                        "segment_id_code": "NM1",
+                        "syntax_error": "Segment Has Data Element Errors",
+                        "syntax_error_code": "8"
+                    }
+                ],
+                "trading_partner_id": "MOCKPAYER",
+                "transaction_set_acknowledgment": "Rejected",
+                "transaction_set_acknowledgment_code": "R",
+                "transaction_set_control_number": "0001",
+                "transaction_set_identifier_code": "270",
+                "transaction_set_syntax_error_codes": [
+                    "I5"
+                ],
+                "transaction_set_syntax_errors": [
+                    "Implementation One or More Segments in Error"
+                ]
+            }
+        }
+    }
+}
+```
+
+```python
+See cURL example.
+```
+
+```ruby
+See cURL example.
+```
+
+```csharp
+See cURL example.
+```
+
+```java
+See cURL example.
+```
+
+```swift
+See cURL example.
+```
+
+
 Error information may be returned to an API client. Common error scenarios
 include:
 
@@ -282,4 +371,13 @@ limit period to renew and then make the API call again.
 You may encounter errors like this when required information is omitted from an
 API call. Simply supply the appropriate information on the next API call to resolve.
 
->
+
+### Trading Partner specific request processing errors
+API requests that route to a specific partner for processing may pass platform validation
+but encounter some partner specific error when the partner attempts to process the
+request data.  If errors like these are encountered, the partner's X12 999 or TA1
+response information will be returned to the API client as an error.  API requests
+that encounter problems like these are not billable.  These types of errors will
+generally pop up if a partner requires some data in their implementation
+for specific members or plans that is generally considered to be optional
+in the X12 transaction's specification.

--- a/source/includes/_common.md
+++ b/source/includes/_common.md
@@ -377,7 +377,6 @@ API requests that route to a specific partner for processing may pass platform v
 but encounter some partner specific error when the partner attempts to process the
 request data.  If errors like these are encountered, the partner's X12 999 or TA1
 response information will be returned to the API client as an error.  API requests
-that encounter problems like these are not billable.  These types of errors will
-generally pop up if a partner requires some data in their implementation
-for specific members or plans that is generally considered to be optional
-in the X12 transaction's specification.
+that encounter problems like these are not billable.  These types of errors will generally
+present if a partner requires data that is generally considered to be optional in the
+X12 transaction's specification.

--- a/source/includes/_eligibility.md
+++ b/source/includes/_eligibility.md
@@ -2167,6 +2167,9 @@ co-insurance, copay, deductible and out of pocket amounts for a member along wit
 Use the [Trading Partners](#trading-partners) endpoint to determine available trading_partner_id values for use with the
 Eligibility API.
 
+See the [errors](#errors) section of the documentation for details on Trading Partner specific request processing errors
+that may occur with this API for some request/partner combinations.
+
 ### Endpoint Description
 
 


### PR DESCRIPTION
Some API interactions may result in a partner returning X12 999 or TA1 data due to the way they've implemented the X12 specification (data that's generally "optional" is not optional for them, etc.)
We now link to the `errors` section from the eligibility and claim status API pages to help folks better understand these types of errors and we include an example X12 999 parsing error response.